### PR TITLE
Bump Flutter iOS dependency to v6.5.0

### DIFF
--- a/embrace/CHANGELOG.md
+++ b/embrace/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 3.1.0
+
+* Updated Embrace iOS SDK to 6.5.0.
+
 # 3.0.1
 
 * Updated Embrace iOS SDK to 6.4.2.

--- a/embrace/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/embrace/example/ios/Runner.xcodeproj/project.pbxproj
@@ -143,6 +143,7 @@
 				3B06AD1E1E4923F5004D2608 /* Thin Binary */,
 				E73B985628D373340073F1DB /* Embrace dSYM upload */,
 				564532501DBDF3BA48CD1500 /* [CP] Embed Pods Frameworks */,
+				6A7947213F00AAB8B9E5CA53 /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -233,6 +234,23 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		6A7947213F00AAB8B9E5CA53 /* [CP] Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-resources-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Copy Pods Resources";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-resources-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-resources.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 		8060760FD4A85B553683A1ED /* [CP] Check Pods Manifest.lock */ = {

--- a/embrace/pubspec.yaml
+++ b/embrace/pubspec.yaml
@@ -1,6 +1,6 @@
 name: embrace
 description: A comprehensive observability and monitoring platform for iOS and Android apps built with Flutter.
-version: 3.0.1
+version: 3.1.0
 homepage: https://embrace.io
 environment:
   sdk: ">=2.12.0 <3.0.0"
@@ -13,9 +13,9 @@ flutter:
       ios:
         default_package: embrace_ios
 dependencies:
-  embrace_android: ">=3.0.1 <3.1.0"
-  embrace_ios: ">=3.0.1 <3.1.0"
-  embrace_platform_interface: ">=3.0.1 <3.1.0"
+  embrace_android: ">=3.1.0 <3.2.0"
+  embrace_ios: ">=3.1.0 <3.2.0"
+  embrace_platform_interface: ">=3.1.0 <3.2.0"
   flutter:
     sdk: flutter
   http: ">=0.13.3 <2.0.0"

--- a/embrace_android/CHANGELOG.md
+++ b/embrace_android/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 3.1.0
+
+* Updated Embrace iOS SDK to 6.5.0.
+
 # 3.0.1
 
 * Updated Embrace iOS SDK to 6.4.2.

--- a/embrace_android/pubspec.yaml
+++ b/embrace_android/pubspec.yaml
@@ -1,6 +1,6 @@
 name: embrace_android
 description: Android implementation of the embrace plugin as defined by the embrace_platform_interface package.
-version: 3.0.1
+version: 3.1.0
 homepage: https://embrace.io
 environment:
   sdk: ">=2.12.0 <3.0.0"
@@ -14,7 +14,7 @@ flutter:
         pluginClass: EmbracePlugin
         dartPluginClass: EmbraceAndroid
 dependencies:
-  embrace_platform_interface: ">=3.0.1 <3.1.0"
+  embrace_platform_interface: ">=3.1.0 <3.2.0"
   flutter:
     sdk: flutter
 dev_dependencies:

--- a/embrace_dio/CHANGELOG.md
+++ b/embrace_dio/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 3.1.0
+
+* Updated Embrace iOS SDK to 6.5.0.
+
 # 3.0.1
 
 * Updated Embrace iOS SDK to 6.4.2.

--- a/embrace_dio/pubspec.yaml
+++ b/embrace_dio/pubspec.yaml
@@ -1,6 +1,6 @@
 name: embrace_dio
 description: Allows automatic Dio network capture when using the the embrace plugin.
-version: 3.0.1
+version: 3.1.0
 homepage: https://embrace.io
 environment:
   sdk: ">=2.12.0 <3.0.0"
@@ -9,12 +9,12 @@ dependencies:
   build_runner: ^2.0.0
   build_version: ^2.0.0
   dio: '>=4.0.0 <6.0.0'
-  embrace: ^3.0.1
+  embrace: 3.1.0
   flutter:
     sdk: flutter
   platform: ^3.1.0
   plugin_platform_interface: ^2.1.0
-  embrace_platform_interface: ">=3.0.1 <3.1.0"
+  embrace_platform_interface: ">=3.1.0 <3.2.0"
 dev_dependencies:
   flutter_test:
     sdk: flutter

--- a/embrace_dio/pubspec.yaml
+++ b/embrace_dio/pubspec.yaml
@@ -9,7 +9,7 @@ dependencies:
   build_runner: ^2.0.0
   build_version: ^2.0.0
   dio: '>=4.0.0 <6.0.0'
-  embrace: 3.1.0
+  embrace: ^3.1.0
   flutter:
     sdk: flutter
   platform: ^3.1.0

--- a/embrace_ios/CHANGELOG.md
+++ b/embrace_ios/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 3.1.0
+
+* Updated Embrace iOS SDK to 6.5.0.
+
 # 3.0.1
 
 * Updated Embrace iOS SDK to 6.4.2.

--- a/embrace_ios/ios/embrace_ios.podspec
+++ b/embrace_ios/ios/embrace_ios.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |s|
   s.source_files = 'Classes/**/*'
   s.public_header_files = 'Classes/**/*.h'
   s.dependency 'Flutter'
-  s.dependency 'EmbraceIO', '6.4.2'
+  s.dependency 'EmbraceIO', '6.5.0'
   s.platform = :ios, '13.0'
   s.swift_version = '5.0'
 

--- a/embrace_ios/pubspec.yaml
+++ b/embrace_ios/pubspec.yaml
@@ -1,6 +1,6 @@
 name: embrace_ios
 description: iOS implementation of the embrace plugin as defined by the embrace_platform_interface package.
-version: 3.0.1
+version: 3.1.0
 homepage: https://embrace.io
 environment:
   sdk: ">=2.12.0 <3.0.0"
@@ -13,7 +13,7 @@ flutter:
         pluginClass: EmbracePlugin
         dartPluginClass: EmbraceIOS
 dependencies:
-  embrace_platform_interface: ">=3.0.1 <3.1.0"
+  embrace_platform_interface: ">=3.1.0 <3.2.0"
   flutter:
     sdk: flutter
 dev_dependencies:

--- a/embrace_platform_interface/CHANGELOG.md
+++ b/embrace_platform_interface/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 3.1.0
+
+* Updated Embrace iOS SDK to 6.5.0.
+
 # 3.0.1
 
 * Updated Embrace iOS SDK to 6.4.2.

--- a/embrace_platform_interface/lib/src/version.dart
+++ b/embrace_platform_interface/lib/src/version.dart
@@ -1,2 +1,2 @@
 // Generated code. Do not modify.
-const packageVersion = '3.0.1';
+const packageVersion = '3.1.0';

--- a/embrace_platform_interface/pubspec.yaml
+++ b/embrace_platform_interface/pubspec.yaml
@@ -1,6 +1,6 @@
 name: embrace_platform_interface
 description: A common platform interface for the Embrace plugin that enables platform-specific implementations.
-version: 3.0.1
+version: 3.1.0
 homepage: https://embrace.io
 environment:
   sdk: ">=2.12.0 <3.0.0"


### PR DESCRIPTION
## Goal

Increases the iOS dependency to 6.5.0.

## Testing

Ran example app & confirmed that sessions are sent to the dashboard.