### PR TITLE
Bump android to 6.14.0, prepare for 3.2.0 release

### DIFF
--- a/embrace/CHANGELOG.md
+++ b/embrace/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 3.2.0
+
+* Updated Embrace Android SDK to 6.14.0.
+
 # 3.1.0
 
 * Updated Embrace iOS SDK to 6.5.0.

--- a/embrace/example/android/build.gradle
+++ b/embrace/example/android/build.gradle
@@ -7,7 +7,7 @@ buildscript {
 
     dependencies {
         classpath "io.embrace:embrace-swazzler:${findProject(':embrace_android').properties['emb_android_sdk']}"
-        classpath 'com.android.tools.build:gradle:7.1.2'
+        classpath 'com.android.tools.build:gradle:7.4.2'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }

--- a/embrace/example/android/gradle/wrapper/gradle-wrapper.properties
+++ b/embrace/example/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,5 @@
-#Fri Jun 23 08:50:38 CEST 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.5.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-bin.zip

--- a/embrace/pubspec.yaml
+++ b/embrace/pubspec.yaml
@@ -1,6 +1,6 @@
 name: embrace
 description: A comprehensive observability and monitoring platform for iOS and Android apps built with Flutter.
-version: 3.1.0
+version: 3.2.0
 homepage: https://embrace.io
 environment:
   sdk: ">=2.12.0 <3.0.0"
@@ -13,9 +13,9 @@ flutter:
       ios:
         default_package: embrace_ios
 dependencies:
-  embrace_android: ">=3.1.0 <3.2.0"
-  embrace_ios: ">=3.1.0 <3.2.0"
-  embrace_platform_interface: ">=3.1.0 <3.2.0"
+  embrace_android: ">=3.2.0 <3.3.0"
+  embrace_ios: ">=3.2.0 <3.3.0"
+  embrace_platform_interface: ">=3.2.0 <3.3.0"
   flutter:
     sdk: flutter
   http: ">=0.13.3 <2.0.0"

--- a/embrace_android/CHANGELOG.md
+++ b/embrace_android/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 3.2.0
+
+* Updated Embrace Android SDK to 6.14.0.
+
 # 3.1.0
 
 * Updated Embrace iOS SDK to 6.5.0.

--- a/embrace_android/android/gradle.properties
+++ b/embrace_android/android/gradle.properties
@@ -1,1 +1,1 @@
-emb_android_sdk=6.13.0
+emb_android_sdk=6.14.0

--- a/embrace_android/pubspec.yaml
+++ b/embrace_android/pubspec.yaml
@@ -1,6 +1,6 @@
 name: embrace_android
 description: Android implementation of the embrace plugin as defined by the embrace_platform_interface package.
-version: 3.1.0
+version: 3.2.0
 homepage: https://embrace.io
 environment:
   sdk: ">=2.12.0 <3.0.0"
@@ -14,7 +14,7 @@ flutter:
         pluginClass: EmbracePlugin
         dartPluginClass: EmbraceAndroid
 dependencies:
-  embrace_platform_interface: ">=3.1.0 <3.2.0"
+  embrace_platform_interface: ">=3.2.0 <3.3.0"
   flutter:
     sdk: flutter
 dev_dependencies:

--- a/embrace_dio/CHANGELOG.md
+++ b/embrace_dio/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 3.2.0
+
+* Updated Embrace Android SDK to 6.14.0.
+
 # 3.1.0
 
 * Updated Embrace iOS SDK to 6.5.0.

--- a/embrace_dio/pubspec.yaml
+++ b/embrace_dio/pubspec.yaml
@@ -1,6 +1,6 @@
 name: embrace_dio
 description: Allows automatic Dio network capture when using the the embrace plugin.
-version: 3.1.0
+version: 3.2.0
 homepage: https://embrace.io
 environment:
   sdk: ">=2.12.0 <3.0.0"
@@ -9,12 +9,12 @@ dependencies:
   build_runner: ^2.0.0
   build_version: ^2.0.0
   dio: '>=4.0.0 <6.0.0'
-  embrace: ^3.1.0
+  embrace: ^3.2.0
   flutter:
     sdk: flutter
   platform: ^3.1.0
   plugin_platform_interface: ^2.1.0
-  embrace_platform_interface: ">=3.1.0 <3.2.0"
+  embrace_platform_interface: ">=3.2.0 <3.3.0"
 dev_dependencies:
   flutter_test:
     sdk: flutter

--- a/embrace_ios/CHANGELOG.md
+++ b/embrace_ios/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 3.2.0
+
+* Updated Embrace Android SDK to 6.14.0.
+
 # 3.1.0
 
 * Updated Embrace iOS SDK to 6.5.0.

--- a/embrace_ios/pubspec.yaml
+++ b/embrace_ios/pubspec.yaml
@@ -1,6 +1,6 @@
 name: embrace_ios
 description: iOS implementation of the embrace plugin as defined by the embrace_platform_interface package.
-version: 3.1.0
+version: 3.2.0
 homepage: https://embrace.io
 environment:
   sdk: ">=2.12.0 <3.0.0"
@@ -13,7 +13,7 @@ flutter:
         pluginClass: EmbracePlugin
         dartPluginClass: EmbraceIOS
 dependencies:
-  embrace_platform_interface: ">=3.1.0 <3.2.0"
+  embrace_platform_interface: ">=3.2.0 <3.3.0"
   flutter:
     sdk: flutter
 dev_dependencies:

--- a/embrace_platform_interface/CHANGELOG.md
+++ b/embrace_platform_interface/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 3.2.0
+
+* Updated Embrace Android SDK to 6.14.0.
+
 # 3.1.0
 
 * Updated Embrace iOS SDK to 6.5.0.

--- a/embrace_platform_interface/lib/method_channel_embrace.dart
+++ b/embrace_platform_interface/lib/method_channel_embrace.dart
@@ -110,7 +110,7 @@ class MethodChannelEmbrace extends EmbracePlatform {
 
   /// Minimum Embrace Android SDK version compatible with this version of
   /// the Embrace Flutter SDK
-  static const String minimumAndroidVersion = '6.13.0';
+  static const String minimumAndroidVersion = '6.14.0';
 
   /// The method channel used to interact with the native platform.
   @visibleForTesting

--- a/embrace_platform_interface/lib/src/version.dart
+++ b/embrace_platform_interface/lib/src/version.dart
@@ -1,2 +1,2 @@
 // Generated code. Do not modify.
-const packageVersion = '3.1.0';
+const packageVersion = '3.2.0';

--- a/embrace_platform_interface/pubspec.yaml
+++ b/embrace_platform_interface/pubspec.yaml
@@ -1,6 +1,6 @@
 name: embrace_platform_interface
 description: A common platform interface for the Embrace plugin that enables platform-specific implementations.
-version: 3.1.0
+version: 3.2.0
 homepage: https://embrace.io
 environment:
   sdk: ">=2.12.0 <3.0.0"

--- a/embrace_platform_interface/test/src/method_channel_embrace_test.dart
+++ b/embrace_platform_interface/test/src/method_channel_embrace_test.dart
@@ -30,7 +30,7 @@ void main() {
             case 'attachToHostSdk':
               return true;
             case 'getSdkVersion':
-              return '6.13.0';
+              return '6.14.0';
             case 'stopSpan':
               return true;
             case 'addSpanEvent':


### PR DESCRIPTION
## Goal

Bumps the Android SDK dependency from 6.13.0 to 6.14.0. I also updated the example app's gradle wrapper + AGP version as part of this. When this is merged, v3.2.0 of our Flutter SDK will be released.

## Testing

Relied on existing test coverage & confirmed that the example app can send sessions to the dashboard.

