### PR TITLE
Harden Android code when the Android SDK doesn't start

### DIFF
--- a/embrace/example/android/app/src/main/kotlin/io/embrace/flutter/example/MyApplication.kt
+++ b/embrace/example/android/app/src/main/kotlin/io/embrace/flutter/example/MyApplication.kt
@@ -7,6 +7,6 @@ import io.embrace.android.embracesdk.Embrace
 class MyApplication : MultiDexApplication() {
     override fun onCreate() {
         super.onCreate()
-        Embrace.getInstance().start(this, false, Embrace.AppFramework.FLUTTER)
+        Embrace.getInstance().start(this, Embrace.AppFramework.FLUTTER)
     }
 }

--- a/embrace/example/android/gradle.properties
+++ b/embrace/example/android/gradle.properties
@@ -1,3 +1,4 @@
-org.gradle.jvmargs=-Xmx1536M
+org.gradle.jvmargs=-Xmx4g -XX:+UseParallelGC -XX:MaxMetaspaceSize=1g
+org.gradle.parallel=true
 android.useAndroidX=true
 android.enableJetifier=true

--- a/embrace/example/android/gradle/wrapper/gradle-wrapper.properties
+++ b/embrace/example/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.5.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.12-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/embrace_android/android/build.gradle
+++ b/embrace_android/android/build.gradle
@@ -9,7 +9,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.1.2'
+        classpath 'com.android.tools.build:gradle:7.4.2'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }
@@ -25,7 +25,7 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdkVersion 31
+    compileSdkVersion 34
 
     if (project.android.hasProperty("namespace")) {
         namespace = "io.embrace.flutter"
@@ -38,8 +38,8 @@ android {
     }
 
     kotlinOptions {
-        apiVersion = '1.4'
-        languageVersion = '1.4'
+        apiVersion = '1.8'
+        languageVersion = '1.8'
         jvmTarget = JavaVersion.VERSION_1_8.toString()
         freeCompilerArgs += '-Xexplicit-api=strict'
     }

--- a/embrace_dio/example/android/app/src/main/java/io/embrace/dio/example/MyApplication.java
+++ b/embrace_dio/example/android/app/src/main/java/io/embrace/dio/example/MyApplication.java
@@ -7,6 +7,6 @@ public final class MyApplication extends FlutterApplication {
     @Override
     public void onCreate() {
         super.onCreate();
-        Embrace.getInstance().start(this, false, Embrace.AppFramework.FLUTTER);
+        Embrace.getInstance().start(this, Embrace.AppFramework.FLUTTER);
     }
 }


### PR DESCRIPTION
## Goal

Hardens the Android code by handling the scenario where the Android SDK hasn't started. This could be due to the SDK being disabled remotely.

## Testing

Manually verified that if the SDK isn't initialized none of the functions crash, regression tested against the dashboard to confirm sessions + data looks as expected.

