### PR TITLE
Avoid failing when logging internal errors

### DIFF
--- a/embrace_platform_interface/lib/method_channel_embrace.dart
+++ b/embrace_platform_interface/lib/method_channel_embrace.dart
@@ -452,7 +452,10 @@ class MethodChannelEmbrace extends EmbracePlatform {
 
   @override
   void logInternalError(String message, String details) {
-    throwIfNotStarted();
+    // don't fail when logging internal errors if not started
+    if (!isStarted) {
+      return;
+    }
     methodChannel.invokeMethod(
       _logInternalErrorMethodName,
       {_messageArgName: message, _detailsArgName: details},


### PR DESCRIPTION
## Goal

Avoid throwing an error if not started when logging an internal error - instead we should silently back out of calling anything.

