### PR TITLE
Avoid failing when logging internal errors

### DIFF
--- a/embrace/CHANGELOG.md
+++ b/embrace/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 4.0.1
+
+* Fixed crash in Dio interceptors when SDK is disabled but interceptor is applied
+
 # 4.0.0
 
 * Updated Embrace Android SDK to 7.1.0

--- a/embrace/pubspec.yaml
+++ b/embrace/pubspec.yaml
@@ -1,6 +1,6 @@
 name: embrace
 description: A comprehensive observability and monitoring platform for iOS and Android apps built with Flutter.
-version: 4.0.0
+version: 4.0.1
 homepage: https://embrace.io
 environment:
   sdk: ">=2.12.0 <3.0.0"
@@ -13,9 +13,9 @@ flutter:
       ios:
         default_package: embrace_ios
 dependencies:
-  embrace_android: ">=4.0.0 <4.1.0"
-  embrace_ios: ">=4.0.0 <4.1.0"
-  embrace_platform_interface: ">=4.0.0 <4.1.0"
+  embrace_android: ">=4.0.1 <4.1.0"
+  embrace_ios: ">=4.0.1 <4.1.0"
+  embrace_platform_interface: ">=4.0.1 <4.1.0"
   flutter:
     sdk: flutter
   http: ">=0.13.3 <2.0.0"

--- a/embrace_android/CHANGELOG.md
+++ b/embrace_android/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 4.0.1
+
+* Fixed crash in Dio interceptors when SDK is disabled but interceptor is applied
+
 # 4.0.0
 
 * Updated Embrace Android SDK to 7.1.0

--- a/embrace_android/pubspec.yaml
+++ b/embrace_android/pubspec.yaml
@@ -1,6 +1,6 @@
 name: embrace_android
 description: Android implementation of the embrace plugin as defined by the embrace_platform_interface package.
-version: 4.0.0
+version: 4.0.1
 homepage: https://embrace.io
 environment:
   sdk: ">=2.12.0 <3.0.0"
@@ -14,7 +14,7 @@ flutter:
         pluginClass: EmbracePlugin
         dartPluginClass: EmbraceAndroid
 dependencies:
-  embrace_platform_interface: ">=4.0.0 <4.1.0"
+  embrace_platform_interface: ">=4.0.1 <4.1.0"
   flutter:
     sdk: flutter
 dev_dependencies:

--- a/embrace_dio/CHANGELOG.md
+++ b/embrace_dio/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 4.0.1
+
+* Fixed crash in Dio interceptors when SDK is disabled but interceptor is applied
+
 # 4.0.0
 
 * Updated Embrace Android SDK to 7.1.0

--- a/embrace_dio/pubspec.yaml
+++ b/embrace_dio/pubspec.yaml
@@ -1,6 +1,6 @@
 name: embrace_dio
 description: Allows automatic Dio network capture when using the the embrace plugin.
-version: 4.0.0
+version: 4.0.1
 homepage: https://embrace.io
 environment:
   sdk: ">=2.12.0 <3.0.0"
@@ -9,12 +9,12 @@ dependencies:
   build_runner: ^2.0.0
   build_version: ^2.0.0
   dio: '>=4.0.0 <6.0.0'
-  embrace: ^4.0.0
+  embrace: ^4.0.1
   flutter:
     sdk: flutter
   platform: ^3.1.0
   plugin_platform_interface: ^2.1.0
-  embrace_platform_interface: ">=4.0.0 <4.1.0"
+  embrace_platform_interface: ">=4.0.1 <4.1.0"
 dev_dependencies:
   flutter_test:
     sdk: flutter

--- a/embrace_ios/CHANGELOG.md
+++ b/embrace_ios/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 4.0.1
+
+* Fixed crash in Dio interceptors when SDK is disabled but interceptor is applied
+
 # 4.0.0
 
 * Updated Embrace Android SDK to 7.1.0

--- a/embrace_ios/pubspec.yaml
+++ b/embrace_ios/pubspec.yaml
@@ -1,6 +1,6 @@
 name: embrace_ios
 description: iOS implementation of the embrace plugin as defined by the embrace_platform_interface package.
-version: 4.0.0
+version: 4.0.1
 homepage: https://embrace.io
 environment:
   sdk: ">=2.12.0 <3.0.0"
@@ -13,7 +13,7 @@ flutter:
         pluginClass: EmbracePlugin
         dartPluginClass: EmbraceIOS
 dependencies:
-  embrace_platform_interface: ">=4.0.0 <4.1.0"
+  embrace_platform_interface: ">=4.0.1 <4.1.0"
   flutter:
     sdk: flutter
 dev_dependencies:

--- a/embrace_platform_interface/CHANGELOG.md
+++ b/embrace_platform_interface/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 4.0.1
+
+* Fixed crash in Dio interceptors when SDK is disabled but interceptor is applied
+
 # 4.0.0
 
 * Updated Embrace Android SDK to 7.1.0

--- a/embrace_platform_interface/lib/method_channel_embrace.dart
+++ b/embrace_platform_interface/lib/method_channel_embrace.dart
@@ -452,7 +452,10 @@ class MethodChannelEmbrace extends EmbracePlatform {
 
   @override
   void logInternalError(String message, String details) {
-    throwIfNotStarted();
+    // don't fail when logging internal errors if not started
+    if (!isStarted) {
+      return;
+    }
     methodChannel.invokeMethod(
       _logInternalErrorMethodName,
       {_messageArgName: message, _detailsArgName: details},

--- a/embrace_platform_interface/lib/src/version.dart
+++ b/embrace_platform_interface/lib/src/version.dart
@@ -1,2 +1,2 @@
 // Generated code. Do not modify.
-const packageVersion = '4.0.0';
+const packageVersion = '4.0.1';

--- a/embrace_platform_interface/pubspec.yaml
+++ b/embrace_platform_interface/pubspec.yaml
@@ -1,6 +1,6 @@
 name: embrace_platform_interface
 description: A common platform interface for the Embrace plugin that enables platform-specific implementations.
-version: 4.0.0
+version: 4.0.1
 homepage: https://embrace.io
 environment:
   sdk: ">=2.12.0 <3.0.0"

--- a/embrace_platform_interface/test/src/method_channel_embrace_test.dart
+++ b/embrace_platform_interface/test/src/method_channel_embrace_test.dart
@@ -915,10 +915,6 @@ void main() {
       });
 
       test('throws StateError if not started', () {
-        expect(
-          () => methodChannelEmbrace.logInternalError(message, details),
-          throwsA(isA<StateError>()),
-        );
         expect(log, isEmpty);
       });
     });


### PR DESCRIPTION
## Goal

Avoid throwing an error if not started when logging an internal error - instead we should silently back out of calling anything.

