### PR TITLE
Use correct attribute key for iOS NSF

### DIFF
--- a/embrace_ios/ios/Classes/EmbracePlugin.swift
+++ b/embrace_ios/ios/Classes/EmbracePlugin.swift
@@ -335,7 +335,7 @@ public class EmbracePlugin: NSObject, FlutterPlugin {
                     let trid = span.context.traceId.hexString
                     let spid = span.context.spanId.hexString
                     let traceParent = W3C.traceparent(traceId: trid, spanId: spid)
-                    span.setAttribute(key: EmbracePlugin.W3cTraceparentArgName, value: traceParent)
+                    span.setAttribute(key: EmbracePlugin.AttrW3cTraceparent, value: traceParent)
                 }
                 span.end(time: Date(timeIntervalSince1970: TimeInterval(endTime) / 1000))
             }


### PR DESCRIPTION
## Goal

Fixes the iOS implementation of network span forwarding to use the correct attribute key. A constant used in the Dart method channel was mistakenly used instead.

