### PR TITLE
Prepare for 4.2.0 release

### DIFF
--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -50,7 +50,7 @@ You can test changes local changes to the iOS SDK by updating the Flutter projec
 0. Bump the Android/iOS dependencies to the latest available stable versions
 1. Bump the SDK version according to semver, with `./set_version.sh <your-version-here> && ./verify_versions.sh`
 2. Update the Android SDK version in `embrace_android/android/gradle.properties` and `embrace_platform_interface/lib/method_channel_embrace.dart`
-3. Update the changelog of all 4 packages with a description of what changed
+3. Update the changelog of all packages with a description of what changed
 4. Run the example app on Android + iOS (in release mode) and confirm that a session is captured & appears in the dashboard with useful info
 5. Create a PR with all these changes
 6. Add the 'release-candidate' label to the PR

--- a/embrace/CHANGELOG.md
+++ b/embrace/CHANGELOG.md
@@ -1,6 +1,7 @@
 # 4.2.0
 
 * Updated Embrace Android SDK to 7.7.0
+* Fixed w3cTraceparent header not being set in Dio/HttpClient requests when network spans forwarding enabled
 
 # 4.1.0
 

--- a/embrace/pubspec.yaml
+++ b/embrace/pubspec.yaml
@@ -1,6 +1,6 @@
 name: embrace
 description: A comprehensive observability and monitoring platform for iOS and Android apps built with Flutter.
-version: 4.1.0
+version: 4.2.0
 homepage: https://embrace.io
 environment:
   sdk: ">=2.12.0 <3.0.0"
@@ -13,9 +13,9 @@ flutter:
       ios:
         default_package: embrace_ios
 dependencies:
-  embrace_android: ">=4.1.0 <4.2.0"
-  embrace_ios: ">=4.1.0 <4.2.0"
-  embrace_platform_interface: ">=4.1.0 <4.2.0"
+  embrace_android: ">=4.2.0 <4.3.0"
+  embrace_ios: ">=4.2.0 <4.3.0"
+  embrace_platform_interface: ">=4.2.0 <4.3.0"
   flutter:
     sdk: flutter
   http: ">=0.13.3 <2.0.0"

--- a/embrace_android/CHANGELOG.md
+++ b/embrace_android/CHANGELOG.md
@@ -1,6 +1,7 @@
 # 4.2.0
 
 * Updated Embrace Android SDK to 7.7.0
+* Fixed w3cTraceparent header not being set in Dio/HttpClient requests when network spans forwarding enabled
 
 # 4.1.0
 

--- a/embrace_android/pubspec.yaml
+++ b/embrace_android/pubspec.yaml
@@ -1,6 +1,6 @@
 name: embrace_android
 description: Android implementation of the embrace plugin as defined by the embrace_platform_interface package.
-version: 4.1.0
+version: 4.2.0
 homepage: https://embrace.io
 environment:
   sdk: ">=2.12.0 <3.0.0"
@@ -14,7 +14,7 @@ flutter:
         pluginClass: EmbracePlugin
         dartPluginClass: EmbraceAndroid
 dependencies:
-  embrace_platform_interface: ">=4.1.0 <4.2.0"
+  embrace_platform_interface: ">=4.2.0 <4.3.0"
   flutter:
     sdk: flutter
 dev_dependencies:

--- a/embrace_dio/CHANGELOG.md
+++ b/embrace_dio/CHANGELOG.md
@@ -1,6 +1,7 @@
 # 4.2.0
 
 * Updated Embrace Android SDK to 7.7.0
+* Fixed w3cTraceparent header not being set in Dio/HttpClient requests when network spans forwarding enabled
 
 # 4.1.0
 

--- a/embrace_dio/pubspec.yaml
+++ b/embrace_dio/pubspec.yaml
@@ -1,6 +1,6 @@
 name: embrace_dio
 description: Allows automatic Dio network capture when using the the embrace plugin.
-version: 4.1.0
+version: 4.2.0
 homepage: https://embrace.io
 environment:
   sdk: ">=2.12.0 <3.0.0"
@@ -9,12 +9,12 @@ dependencies:
   build_runner: ^2.0.0
   build_version: ^2.0.0
   dio: '>=4.0.0 <6.0.0'
-  embrace: ^4.1.0
+  embrace: ^4.2.0
   flutter:
     sdk: flutter
   platform: ^3.1.0
   plugin_platform_interface: ^2.1.0
-  embrace_platform_interface: ">=4.1.0 <4.2.0"
+  embrace_platform_interface: ">=4.2.0 <4.3.0"
 dev_dependencies:
   flutter_test:
     sdk: flutter

--- a/embrace_ios/CHANGELOG.md
+++ b/embrace_ios/CHANGELOG.md
@@ -1,6 +1,7 @@
 # 4.2.0
 
 * Updated Embrace Android SDK to 7.7.0
+* Fixed w3cTraceparent header not being set in Dio/HttpClient requests when network spans forwarding enabled
 
 # 4.1.0
 

--- a/embrace_ios/ios/Classes/EmbracePlugin.swift
+++ b/embrace_ios/ios/Classes/EmbracePlugin.swift
@@ -200,6 +200,8 @@ public class EmbracePlugin: NSObject, FlutterPlugin {
                 handleAddSpanAttributeCall(call, result: result)
             case EmbracePlugin.RecordCompletedSpanMethodName:
                 handleRecordCompletedSpanCall(call, result: result)
+            case EmbracePlugin.GenerateW3cTraceparentMethodName:
+                handleGenerateW3cTraceparentCall(call, result: result)
             case EmbracePlugin.GetTraceIdMethodName:
                 handleGetTraceIdCall(call, result: result)
             default:
@@ -601,8 +603,9 @@ public class EmbracePlugin: NSObject, FlutterPlugin {
                     let errorCode = args[EmbracePlugin.ErrorCodeArgName] as? String
                     let success = repository.stopSpan(spanId: spanId, endTimeMs: endTimeMs, errorCode: errorCode)
                     result(NSNumber(value: success))
+                } else {
+                    result(NSNumber(value: false))
                 }
-                result(NSNumber(value: false))
         }
     }
 
@@ -615,8 +618,9 @@ public class EmbracePlugin: NSObject, FlutterPlugin {
                     let attrs = args[EmbracePlugin.AttributesArgName] as? [String: String] ?? [:]
                     let success = repository.addSpanEvent(spanId: spanId, name: name, timestampMs: timestampMs, attributes: attrs)
                     result(NSNumber(value: success))
+                } else {
+                    result(NSNumber(value: false))
                 }
-                result(NSNumber(value: false))
         }
     }
 
@@ -628,8 +632,9 @@ public class EmbracePlugin: NSObject, FlutterPlugin {
                 let valueObj = args[EmbracePlugin.ValueArgName] as? String {
                     let success = repository.addSpanAttribute(spanId: spanId, key: keyObj, value: valueObj)
                     result(NSNumber(value: success))
+                } else {
+                    result(NSNumber(value: false))
                 }
-                result(NSNumber(value: false))
         }
     }
 
@@ -645,8 +650,9 @@ public class EmbracePlugin: NSObject, FlutterPlugin {
                     let events = args[EmbracePlugin.EventsArgName] as? Array<Dictionary<String, Any>> ?? []
                     let success = repository.recordCompletedSpan(name: name, startTimeMs: startTimeMs, endTimeMs: endTimeMs, errorCode: errorCode, parentSpanId: parentSpanId, attributes: attrs, events: events)
                     result(NSNumber(value: success))
+                } else {
+                    result(nil)
                 }
-                result(nil)
         }
     }
 
@@ -655,10 +661,10 @@ public class EmbracePlugin: NSObject, FlutterPlugin {
             if let args = call.arguments as? [String: Any],
                 let traceId = args[EmbracePlugin.TraceIdArgName] as? String,
                 let spanId = args[EmbracePlugin.SpanIdArgName] as? String {
-                let traceparent = W3C.traceparent(traceId: traceId, spanId: spanId)
-                result(traceparent)
+                result(W3C.traceparent(traceId: traceId, spanId: spanId))
+            } else {
+                result(W3C.traceparent(traceId: TraceId.random().hexString, spanId: SpanId.random().hexString))
             }
-            result(nil)
         }
     }
 
@@ -668,8 +674,9 @@ public class EmbracePlugin: NSObject, FlutterPlugin {
                 let spanId = args[EmbracePlugin.SpanIdArgName] as? String,
                 let span = repository.findSpan(id: spanId) {
                 result(span.context.traceId.hexString)
+            } else {
+                result(nil)
             }
-            result(nil)
         }
     }
 

--- a/embrace_ios/pubspec.yaml
+++ b/embrace_ios/pubspec.yaml
@@ -1,6 +1,6 @@
 name: embrace_ios
 description: iOS implementation of the embrace plugin as defined by the embrace_platform_interface package.
-version: 4.1.0
+version: 4.2.0
 homepage: https://embrace.io
 environment:
   sdk: ">=2.12.0 <3.0.0"
@@ -13,7 +13,7 @@ flutter:
         pluginClass: EmbracePlugin
         dartPluginClass: EmbraceIOS
 dependencies:
-  embrace_platform_interface: ">=4.1.0 <4.2.0"
+  embrace_platform_interface: ">=4.2.0 <4.3.0"
   flutter:
     sdk: flutter
 dev_dependencies:

--- a/embrace_platform_interface/CHANGELOG.md
+++ b/embrace_platform_interface/CHANGELOG.md
@@ -1,6 +1,7 @@
 # 4.2.0
 
 * Updated Embrace Android SDK to 7.7.0
+* Fixed w3cTraceparent header not being set in Dio/HttpClient requests when network spans forwarding enabled
 
 # 4.1.0
 

--- a/embrace_platform_interface/lib/src/version.dart
+++ b/embrace_platform_interface/lib/src/version.dart
@@ -1,2 +1,2 @@
 // Generated code. Do not modify.
-const packageVersion = '4.1.0';
+const packageVersion = '4.2.0';

--- a/embrace_platform_interface/pubspec.yaml
+++ b/embrace_platform_interface/pubspec.yaml
@@ -1,6 +1,6 @@
 name: embrace_platform_interface
 description: A common platform interface for the Embrace plugin that enables platform-specific implementations.
-version: 4.1.0
+version: 4.2.0
 homepage: https://embrace.io
 environment:
   sdk: ">=2.12.0 <3.0.0"


### PR DESCRIPTION
## Goal

Prepares for the 4.2.0 release. When this PR is merged the release will be triggered. The changeset includes a fix to the iOS layer where a function was not included in a switch statement so wasn't invoked, and changelog/version bumps.

## Testing

I ran the example apps using the HttpClient library to confirm the w3cTraceparent header is injected, and checked that a traceparent is shown in the dashboard for both Android/iOS requests.

