### PR TITLE
Create Android/Apple SDK updates as draft

### DIFF
--- a/.github/workflows/update-native-sdks.yaml
+++ b/.github/workflows/update-native-sdks.yaml
@@ -73,7 +73,7 @@ jobs:
               git commit --all --message "Update ${SDK} from ${CURRENT} to ${LATEST}"
               git push origin $branch
 
-              gh pr create --fill --label $SDK --body "See https://github.com/embrace-io/${SDK}/releases/tag/${LATEST}"
-              # https://github.com/cli/cli/issues/11360 --reviewer @embrace-io/opensource-${{ matrix.platform }}
+              gh pr create --fill --label $SDK --body "See https://github.com/embrace-io/${SDK}/releases/tag/${LATEST}" --draft
+              # https://github.com/cli/cli/issues/11360 --reviewer @${{ github.repository_owner }}/opensource-${{ matrix.platform }} --assignee @${{ github.repository_owner }}/opensource-flutter
             fi
           fi


### PR DESCRIPTION
As a safety feature, GitHub does not run workflows on PRs created by other workflows, so the workaround is to use a draft and once a human marks draft as ready then the tests will run.

Also, used `github.repository_owner` instead of hardcoding embrace-io so it is safer for this to run in forks.