### PR TITLE
Refactor span stopping to use safeSdkCall

### DIFF
--- a/embrace_android/android/src/main/kotlin/io/embrace/flutter/EmbracePlugin.kt
+++ b/embrace_android/android/src/main/kotlin/io/embrace/flutter/EmbracePlugin.kt
@@ -636,9 +636,11 @@ public class EmbracePlugin : FlutterPlugin, MethodCallHandler {
         val spanId = call.getStringArgument(EmbraceConstants.SPAN_ID_ARG_NAME)
         val errorCode = call.getErrorCode(EmbraceConstants.ERROR_CODE_ARG_NAME)
         val endTimeMs: Long? = call.argument(EmbraceConstants.END_TIME_MS_ARG_NAME)
-        val success = safeFlutterInterfaceCall {
-            stopSpan(spanId, errorCode, endTimeMs)
+        val success = safeSdkCall {  
+            val span = getSpan(spanId)
+            span?.stop(errorCode, endTimeMs)
         }
+
         result.success(success)
     }
 


### PR DESCRIPTION
Replaces safeFlutterInterfaceCall with safeSdkCall when stopping a span. Retrieves the span by ID and calls stop directly

## Goal

<!-- Describe what this change seeks to address -->

## Testing

<!-- Describe how this change has been tested -->

## Release Notes

<!-- Notes to add in the next Release. Ignore if the changes are internal. -->

**WHAT**:<br>
**WHY**:<br>
**WHO**:<br>

