### PR TITLE
Refactor span event addition to use safeSdkCall

### DIFF
--- a/embrace_android/android/src/main/kotlin/io/embrace/flutter/EmbracePlugin.kt
+++ b/embrace_android/android/src/main/kotlin/io/embrace/flutter/EmbracePlugin.kt
@@ -647,8 +647,9 @@ public class EmbracePlugin : FlutterPlugin, MethodCallHandler {
         val name = call.getStringArgument(EmbraceConstants.NAME_ARG_NAME)
         val timestampMs: Long? = call.argument(EmbraceConstants.TIMESTAMP_MS_ARG_NAME)
         val attributes = call.getMapArgument<String>(EmbraceConstants.ATTRIBUTES_ARG_NAME)
-        val success = safeFlutterInterfaceCall {
-            addSpanEvent(spanId, name, timestampMs, attributes)
+        val success = safeSdkCall { 
+            val span = getSpan(spanId)
+            span?.addEvent(name, timestampMs, attributes)
         }
         result.success(success)
     }


### PR DESCRIPTION
Replaces safeFlutterInterfaceCall with safeSdkCall when adding span events. Now retrieves the span by ID and adds the event directly.

## Goal

<!-- Describe what this change seeks to address -->

## Testing

<!-- Describe how this change has been tested -->

## Release Notes

<!-- Notes to add in the next Release. Ignore if the changes are internal. -->

**WHAT**:<br>
**WHY**:<br>
**WHO**:<br>

