### PR TITLE
Refactor span attribute addition to use safeSdkCall

### DIFF
--- a/embrace_android/android/src/main/kotlin/io/embrace/flutter/EmbracePlugin.kt
+++ b/embrace_android/android/src/main/kotlin/io/embrace/flutter/EmbracePlugin.kt
@@ -21,7 +21,6 @@ import android.os.Looper
 import io.embrace.android.embracesdk.Severity
 import io.embrace.android.embracesdk.network.EmbraceNetworkRequest
 import io.embrace.android.embracesdk.spans.ErrorCode
-import io.embrace.android.embracesdk.spans.EmbraceSpanEvent
 
 internal object EmbraceConstants {
     internal const val METHOD_CHANNEL_ID : String = "embrace"
@@ -673,11 +672,9 @@ public class EmbracePlugin : FlutterPlugin, MethodCallHandler {
         val parentSpanId: String? = call.argument(EmbraceConstants.PARENT_SPAN_ID_ARG_NAME)
         val attributes = call.getMapArgument<String>(EmbraceConstants.ATTRIBUTES_ARG_NAME)
         val events = call.getListArgument<Map<String, Any>>(EmbraceConstants.EVENTS_ARG_NAME)
-        val success = safeSdkCall { 
-            val parent = parentSpanId?.let { getSpan(it) }
-            val spanEvents = events.mapNotNull { mapToEvent(it) }
-            recordCompletedSpan(name, startTimeMs, endTimeMs, errorCode, parent, attributes, spanEvents)
-         }
+        val success = safeFlutterInterfaceCall {
+            recordCompletedSpan(name, startTimeMs, endTimeMs, errorCode, parentSpanId, attributes, events)
+        }
         result.success(success)
     }
 
@@ -688,37 +685,5 @@ public class EmbracePlugin : FlutterPlugin, MethodCallHandler {
             span?.traceId
         }
         result.success(traceId)
-    }
-
-    private fun mapToEvent(map: Map<String, Any>): EmbraceSpanEvent? {
-        val name = map["name"]
-        val timestampMs = map["timestampMs"] as? Long?
-        val timestampNanos = (map["timestampNanos"] as? Long?)?.nanosToMillis()
-        val attributes = map["attributes"]
-
-        // If timestampMs is specified but isn't the right type, return and don't create the event
-        if (timestampMs == null && map["timestampMs"] != null) {
-            return null
-        }
-
-        // If timestampMs is valid, use it
-        // else if timestampNanos is valid, use it
-        // else if timestampNanos isn't specified, use the current time in millis
-        // Otherwise, it means we have an invalid type of timestampNanos so we don't create the event
-        val validatedTimeMs = timestampMs ?: timestampNanos ?: if (map["timestampNanos"] == null) {
-            System.currentTimeMillis()
-        } else {
-            return null
-        }
-
-        return if (name is String && attributes is Map<*, *>?) {
-            EmbraceSpanEvent.create(
-                name = name,
-                timestampMs = validatedTimeMs,
-                attributes = attributes?.let { toStringMap(it) }
-            )
-        } else {
-            null
-        }
     }
 }


### PR DESCRIPTION
Replaces the use of safeFlutterInterfaceCall with safeSdkCall when adding attributes to a span.

## Goal

<!-- Describe what this change seeks to address -->

## Testing

<!-- Describe how this change has been tested -->

## Release Notes

<!-- Notes to add in the next Release. Ignore if the changes are internal. -->

**WHAT**:<br>
**WHY**:<br>
**WHO**:<br>

