### PR TITLE
Removed internal API call 'recordCompletedSpan'

### DIFF
--- a/embrace_android/android/src/main/kotlin/io/embrace/flutter/EmbracePlugin.kt
+++ b/embrace_android/android/src/main/kotlin/io/embrace/flutter/EmbracePlugin.kt
@@ -118,6 +118,13 @@ internal object EmbraceConstants {
     internal const val EVENTS_ARG_NAME : String = "events"
 }
 
+/**
+ * Extension function to convert nanoseconds to milliseconds.
+ */
+private fun Long.nanosToMillis(): Long {
+    return this / 1_000_000
+}
+
 /** EmbracePlugin */
 public class EmbracePlugin : FlutterPlugin, MethodCallHandler {
     /// The MethodChannel that will the communication between Flutter and native Android
@@ -719,5 +726,11 @@ public class EmbracePlugin : FlutterPlugin, MethodCallHandler {
         } else {
             null
         }
+    }
+
+    private fun toStringMap(map: Map<*, *>): Map<String, String> =
+        map.entries
+            .filter { it.key is String && it.value is String }
+            .associate { Pair(it.key.toString(), it.value.toString()) 
     }
 }


### PR DESCRIPTION
We are using the public API here and mapping the events now to objects the SDK expects

## Goal

<!-- Describe what this change seeks to address -->

## Testing

<!-- Describe how this change has been tested -->

## Release Notes

<!-- Notes to add in the next Release. Ignore if the changes are internal. -->

**WHAT**:<br>
**WHY**:<br>
**WHO**:<br>

