### PR TITLE
Add OTel span adapter and move span models

### DIFF
--- a/embrace/lib/embrace.dart
+++ b/embrace/lib/embrace.dart
@@ -554,7 +554,8 @@ class EmbraceSpanImpl extends EmbraceSpan {
   final EmbracePlatform _platform;
 
   @override
-  Future<String?> get traceId async => _platform.getTraceId(id);
+  Future<String> get traceId async =>
+      await _platform.getTraceId(id) ?? '0' * 32;
 
   @override
   Future<bool> stop({ErrorCode? errorCode, int? endTimeMs}) {

--- a/embrace/lib/embrace_api.dart
+++ b/embrace/lib/embrace_api.dart
@@ -14,8 +14,11 @@ abstract class EmbraceSpan {
   /// ID for this span
   final String id;
 
-  /// ID for the trace this span belongs to
-  abstract final Future<String?> traceId;
+  /// ID for the trace this span belongs to.
+  ///
+  /// Returns the all-zeros string if the trace ID is unavailable or invalid,
+  /// consistent with the OTel convention for an invalid trace ID.
+  abstract final Future<String> traceId;
 
   /// Stop an active span. Returns true if the span is stopped after the method
   /// returns and false otherwise.

--- a/embrace_platform_interface/lib/embrace_platform_interface.dart
+++ b/embrace_platform_interface/lib/embrace_platform_interface.dart
@@ -36,7 +36,10 @@ abstract class EmbraceSpanDelegate {
   String get id;
 
   /// ID for the trace this span belongs to.
-  Future<String?> get traceId;
+  ///
+  /// Returns the all-zeros string if the trace ID is unavailable or invalid,
+  /// consistent with the OTel convention for an invalid trace ID.
+  Future<String> get traceId;
 
   /// Stop an active span. Returns true if the span is stopped after the method
   /// returns and false otherwise.

--- a/embrace_platform_interface/lib/src/otel/otel_span_adapter.dart
+++ b/embrace_platform_interface/lib/src/otel/otel_span_adapter.dart
@@ -9,9 +9,8 @@ import 'package:embrace_platform_interface/embrace_platform_interface.dart';
 /// [SpanContext.traceId] must be synchronous, construction is asynchronous.
 /// Use the [create] factory to instantiate.
 ///
-/// If the native trace ID is null or cannot be parsed as a valid 32-character
-/// hex string, [SpanContext.isValid] will be false (the trace ID bytes will be
-/// all zeros).
+/// If the native trace ID cannot be parsed as a valid 32-character hex string,
+/// [SpanContext.isValid] will be false (the trace ID bytes will be all zeros).
 class OTelSpanAdapter {
   OTelSpanAdapter._({
     required String name,
@@ -112,10 +111,9 @@ class OTelSpanAdapter {
   // Private helpers
   // ---------------------------------------------------------------------------
 
-  static SpanContext _buildSpanContext(String spanId, String? traceId) {
+  static SpanContext _buildSpanContext(String spanId, String traceId) {
     final spanIdBytes = _tryParseHex(spanId, SpanId.spanIdLength);
-    final traceIdBytes =
-        traceId != null ? _tryParseHex(traceId, TraceId.traceIdLength) : null;
+    final traceIdBytes = _tryParseHex(traceId, TraceId.traceIdLength);
 
     return SpanContextCreate.create(
       spanId: SpanIdCreate.create(

--- a/embrace_platform_interface/test/src/otel/otel_span_adapter_test.dart
+++ b/embrace_platform_interface/test/src/otel/otel_span_adapter_test.dart
@@ -58,8 +58,8 @@ void main() {
       expect(adapter.spanContext.isValid, isTrue);
     });
 
-    test('spanContext is invalid when traceId is null', () async {
-      when(() => mockSpan.traceId).thenAnswer((_) async => null);
+    test('spanContext is invalid when traceId is all zeros', () async {
+      when(() => mockSpan.traceId).thenAnswer((_) async => kInvalidTraceId);
       final adapter = await OTelSpanAdapter.create(kTestSpanName, mockSpan);
       expect(adapter.spanContext.isValid, isFalse);
     });

--- a/embrace_platform_interface/test/src/otel/otel_test_fixtures.dart
+++ b/embrace_platform_interface/test/src/otel/otel_test_fixtures.dart
@@ -6,5 +6,8 @@ const String kTestSpanId = 'a1b2c3d4e5f6a7b8';
 /// Valid 32-character hex string (16 bytes) for use as a trace ID.
 const String kTestTraceId = '00112233445566778899aabbccddeeff';
 
+/// All-zeros trace ID — the OTel sentinel for an invalid trace ID.
+const String kInvalidTraceId = '00000000000000000000000000000000';
+
 /// Span name used across OTel adapter tests.
 const String kTestSpanName = 'test-span';


### PR DESCRIPTION
Move EmbraceSpan and EmbraceSpanEvent into the platform interface and re-export them from embrace_api. 

Add an OTelSpanAdapter that adapts EmbraceSpan to the dartastic_opentelemetry_api span model (async factory to resolve traceId, SpanContext construction, hex parsing, attribute/event delegation, end/status mapping). 

Add unit tests and shared fixtures for the adapter (otel_span_adapter_test.dart and otel_test_fixtures.dart). 

This centralizes span types in the platform interface and provides a tested bridge to OpenTelemetry.

