### PR TITLE
feat(otel): add addSpanExporter / addLogRecordExporter with native handlers

### DIFF
--- a/embrace/lib/embrace.dart
+++ b/embrace/lib/embrace.dart
@@ -288,6 +288,42 @@ class Embrace implements EmbraceFlutterApi {
     return _platform.getDeviceId();
   }
 
+  /// Returns the [EmbraceTracerProvider] registered with the OTel API.
+  ///
+  /// Throws a [StateError] if called before [start].
+  EmbraceTracerProvider get tracerProvider {
+    if (OTelFactory.otelFactory == null) {
+      throw StateError('Embrace SDK has not been started.');
+    }
+    return OTelAPI.tracerProvider() as EmbraceTracerProvider;
+  }
+
+  /// Returns the [EmbraceLoggerProvider] registered with the OTel API.
+  ///
+  /// Throws a [StateError] if called before [start].
+  EmbraceLoggerProvider get loggerProvider {
+    if (OTelFactory.otelFactory == null) {
+      throw StateError('Embrace SDK has not been started.');
+    }
+    return OTelAPI.loggerProvider() as EmbraceLoggerProvider;
+  }
+
+  /// Resets SDK state for use in tests.
+  ///
+  /// Clears pending exporter queues on both providers (if the OTel API has
+  /// been initialised) then resets the OTel API.
+  @visibleForTesting
+  void resetForTesting() {
+    if (OTelFactory.otelFactory != null) {
+      // ignore: invalid_use_of_visible_for_testing_member
+      (OTelAPI.tracerProvider() as EmbraceTracerProvider).resetForTesting();
+      // ignore: invalid_use_of_visible_for_testing_member
+      (OTelAPI.loggerProvider() as EmbraceLoggerProvider).resetForTesting();
+    }
+    // ignore: invalid_use_of_visible_for_testing_member
+    OTelAPI.reset();
+  }
+
   @override
   void logDartError(Object error, StackTrace stack) {
     EmbracePlatform.instance.logDartError(
@@ -459,6 +495,9 @@ Future<void> _start(
       oTelFactoryCreationFunction: EmbraceOTelFactory.new,
     );
   }
+
+  (OTelAPI.tracerProvider() as EmbraceTracerProvider).flushPendingExporters();
+  (OTelAPI.loggerProvider() as EmbraceLoggerProvider).flushPendingExporters();
 
   if (action != null) {
     await _installErrorHandlers(action);

--- a/embrace/lib/src/otel/embrace_otel_factory.dart
+++ b/embrace/lib/src/otel/embrace_otel_factory.dart
@@ -1,4 +1,5 @@
 import 'package:dartastic_opentelemetry_api/dartastic_opentelemetry_api.dart';
+import 'package:embrace/src/otel/logs/embrace_logger_provider.dart';
 import 'package:embrace/src/otel/tracing/embrace_tracer_provider.dart';
 import 'package:meta/meta.dart';
 
@@ -28,6 +29,19 @@ class EmbraceOTelFactory extends OTelAPIFactory {
     String? serviceVersion = OTelAPI.defaultServiceVersion,
   }) {
     return EmbraceTracerProvider(
+      endpoint: endpoint,
+      serviceName: serviceName,
+      serviceVersion: serviceVersion,
+    );
+  }
+
+  @override
+  APILoggerProvider loggerProvider({
+    required String endpoint,
+    String serviceName = OTelAPI.defaultServiceName,
+    String? serviceVersion = OTelAPI.defaultServiceVersion,
+  }) {
+    return EmbraceLoggerProvider(
       endpoint: endpoint,
       serviceName: serviceName,
       serviceVersion: serviceVersion,

--- a/embrace/lib/src/otel/logs/embrace_logger_provider.dart
+++ b/embrace/lib/src/otel/logs/embrace_logger_provider.dart
@@ -1,23 +1,23 @@
 import 'package:dartastic_opentelemetry_api/dartastic_opentelemetry_api.dart';
-import 'package:embrace/src/otel/tracing/embrace_tracer.dart';
 import 'package:embrace_platform_interface/embrace_platform_interface.dart';
 import 'package:meta/meta.dart';
 
-typedef _SpanExporterConfig = ({
+typedef _LogExporterConfig = ({
   String endpoint,
   List<Map<String, String>>? headers,
   int? timeoutSeconds,
 });
 
-/// Embrace implementation of [APITracerProvider].
+/// Embrace implementation of [APILoggerProvider].
 ///
-/// Holds a single [EmbraceTracer] instance returned by every [getTracer] call.
-/// Registered via the Embrace OTel factory so that [OTelAPI.tracerProvider]
-/// returns this provider after Embrace.start is called.
+/// Delegates [getLogger] to the OTel API no-op implementation. The primary
+/// purpose of this class is to manage OTLP HTTP log record exporter
+/// configuration: calls may be queued before [EmbracePlatform.attachToHostSdk]
+/// and forwarded to the native SDK once [flushPendingExporters] is called.
 @internal
-class EmbraceTracerProvider implements APITracerProvider {
-  /// Creates an [EmbraceTracerProvider].
-  EmbraceTracerProvider({
+class EmbraceLoggerProvider implements APILoggerProvider {
+  /// Creates an [EmbraceLoggerProvider].
+  EmbraceLoggerProvider({
     required String endpoint,
     String serviceName = OTelAPI.defaultServiceName,
     String? serviceVersion = OTelAPI.defaultServiceVersion,
@@ -27,74 +27,72 @@ class EmbraceTracerProvider implements APITracerProvider {
         _enabled = true,
         _isShutdown = false;
 
-  late final EmbraceTracer _tracer = EmbraceTracer(provider: this);
-
-  // endpoint, serviceName, and serviceVersion satisfy the APITracerProvider
-  // interface but are not used by the Dart layer — the native Embrace SDK owns
-  // these values and manages them independently.
   String _endpoint;
   String _serviceName;
   String? _serviceVersion;
   bool _enabled;
   bool _isShutdown;
 
-  final List<_SpanExporterConfig> _pendingSpanExporters = [];
+  final List<_LogExporterConfig> _pendingLogExporters = [];
 
-  /// Returns the single [EmbraceTracer] instance regardless of [name],
-  /// [version], [schemaUrl], or [attributes]. All instrumentation shares one
-  /// tracer because span creation is delegated entirely to the native Embrace
-  /// SDK, which does not distinguish between OTel instrumentation scopes.
-  @override
-  APITracer getTracer(
-    String name, {
-    String? version,
-    String? schemaUrl,
-    Attributes? attributes,
-  }) =>
-      _tracer;
-
-  /// Adds an OTLP HTTP span exporter.
+  /// Adds an OTLP HTTP log record exporter.
   ///
   /// If the Embrace SDK has already started, the exporter is configured on the
   /// native SDK immediately. Otherwise the config is queued and forwarded once
   /// [flushPendingExporters] is called after the SDK starts.
-  void addSpanExporter({
+  void addLogRecordExporter({
     required String endpoint,
     List<Map<String, String>>? headers,
     int? timeoutSeconds,
   }) {
     if (EmbracePlatform.instance.isStarted) {
-      EmbracePlatform.instance.addSpanExporter(
+      EmbracePlatform.instance.addLogRecordExporter(
         endpoint: endpoint,
         headers: headers,
         timeoutSeconds: timeoutSeconds,
       );
     } else {
-      _pendingSpanExporters.add(
+      _pendingLogExporters.add(
         (endpoint: endpoint, headers: headers, timeoutSeconds: timeoutSeconds),
       );
     }
   }
 
-  /// Forwards all queued span exporter configs to the native SDK.
+  /// Forwards all queued log record exporter configs to the native SDK.
   ///
   /// Called by `Embrace._start` after [EmbracePlatform.attachToHostSdk].
   void flushPendingExporters() {
-    for (final config in List.of(_pendingSpanExporters)) {
-      EmbracePlatform.instance.addSpanExporter(
+    for (final config in List.of(_pendingLogExporters)) {
+      EmbracePlatform.instance.addLogRecordExporter(
         endpoint: config.endpoint,
         headers: config.headers,
         timeoutSeconds: config.timeoutSeconds,
       );
     }
-    _pendingSpanExporters.clear();
+    _pendingLogExporters.clear();
   }
 
   /// Clears the pending exporter queue. For use in tests only.
   @visibleForTesting
   void resetForTesting() {
-    _pendingSpanExporters.clear();
+    _pendingLogExporters.clear();
   }
+
+  // ── APILoggerProvider interface ──────────────────────────────────────────
+
+  @override
+  APILogger getLogger(
+    String name, {
+    String? version,
+    String? schemaUrl,
+    Attributes? attributes,
+  }) =>
+      LoggerCreate.create(
+        name: name,
+        version: version,
+        schemaUrl: schemaUrl,
+        attributes: attributes,
+      );
 
   @override
   Future<bool> shutdown() async {

--- a/embrace/lib/src/otel/otel.dart
+++ b/embrace/lib/src/otel/otel.dart
@@ -1,4 +1,5 @@
 export 'package:embrace/src/otel/embrace_otel_factory.dart';
+export 'package:embrace/src/otel/logs/embrace_logger_provider.dart';
 export 'package:embrace/src/otel/propagation/w3c_trace_context.dart';
 export 'package:embrace/src/otel/tracing/embrace_otel_span.dart';
 export 'package:embrace/src/otel/tracing/embrace_tracer.dart';

--- a/embrace/test/embrace_test.dart
+++ b/embrace/test/embrace_test.dart
@@ -5,6 +5,10 @@ import 'package:dartastic_opentelemetry_api/dartastic_opentelemetry_api.dart'
     as otel;
 import 'package:embrace/embrace.dart';
 import 'package:embrace/embrace_api.dart';
+// ignore: implementation_imports
+import 'package:embrace/src/otel/logs/embrace_logger_provider.dart';
+// ignore: implementation_imports
+import 'package:embrace/src/otel/tracing/embrace_tracer_provider.dart';
 import 'package:embrace_platform_interface/embrace_platform_interface.dart';
 import 'package:embrace_platform_interface/last_run_end_state.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -1223,6 +1227,107 @@ void main() {
         verify(
           () => embracePlatform.addSpanAttribute(id, key, value),
         ).called(1);
+      });
+    });
+
+    group('OTel provider accessors', () {
+      setUp(() {
+        when(
+          () => embracePlatform.attachToHostSdk(
+            enableIntegrationTesting: any(named: 'enableIntegrationTesting'),
+          ),
+        ).thenAnswer((_) async => true);
+        when(
+          () => embracePlatform.addSpanExporter(
+            endpoint: any(named: 'endpoint'),
+            headers: any(named: 'headers'),
+            timeoutSeconds: any(named: 'timeoutSeconds'),
+          ),
+        ).thenReturn(null);
+        when(
+          () => embracePlatform.addLogRecordExporter(
+            endpoint: any(named: 'endpoint'),
+            headers: any(named: 'headers'),
+            timeoutSeconds: any(named: 'timeoutSeconds'),
+          ),
+        ).thenReturn(null);
+      });
+
+      test(
+        'tracerProvider returns EmbraceTracerProvider after start',
+        () async {
+          await Embrace.instance.start();
+
+          expect(
+            Embrace.instance.tracerProvider,
+            isA<EmbraceTracerProvider>(),
+          );
+        },
+      );
+
+      test(
+        'loggerProvider returns EmbraceLoggerProvider after start',
+        () async {
+          await Embrace.instance.start();
+
+          expect(
+            Embrace.instance.loggerProvider,
+            isA<EmbraceLoggerProvider>(),
+          );
+        },
+      );
+
+      test('tracerProvider throws StateError before start', () {
+        expect(
+          () => Embrace.instance.tracerProvider,
+          throwsA(isA<StateError>()),
+        );
+      });
+
+      test('loggerProvider throws StateError before start', () {
+        expect(
+          () => Embrace.instance.loggerProvider,
+          throwsA(isA<StateError>()),
+        );
+      });
+
+      test('resetForTesting() clears pending exporter queues', () async {
+        // Start so providers are registered with OTelAPI
+        await Embrace.instance.start();
+
+        // Hold references before reset
+        final tracerProvider = Embrace.instance.tracerProvider;
+        final loggerProvider = Embrace.instance.loggerProvider;
+
+        // Mock isStarted false so subsequent additions are queued
+        when(() => embracePlatform.isStarted).thenReturn(false);
+        tracerProvider.addSpanExporter(endpoint: 'https://spans.example.com');
+        loggerProvider.addLogRecordExporter(
+          endpoint: 'https://logs.example.com',
+        );
+
+        // Reset clears both queues
+        // ignore: invalid_use_of_visible_for_testing_member
+        Embrace.instance.resetForTesting();
+
+        // Flush should be a no-op — queues were cleared
+        tracerProvider.flushPendingExporters();
+        loggerProvider.flushPendingExporters();
+
+        verifyNever(
+          () => embracePlatform.addSpanExporter(
+            endpoint: any(named: 'endpoint'),
+            headers: any(named: 'headers'),
+            timeoutSeconds: any(named: 'timeoutSeconds'),
+          ),
+        );
+        verifyNever(
+          () => embracePlatform.addLogRecordExporter(
+            endpoint: any(named: 'endpoint'),
+            headers: any(named: 'headers'),
+            timeoutSeconds: any(named: 'timeoutSeconds'),
+          ),
+        );
       });
     });
   });

--- a/embrace/test/src/otel/logs/embrace_logger_provider_test.dart
+++ b/embrace/test/src/otel/logs/embrace_logger_provider_test.dart
@@ -1,0 +1,184 @@
+import 'package:dartastic_opentelemetry_api/dartastic_opentelemetry_api.dart';
+// ignore: implementation_imports
+import 'package:embrace/src/otel/logs/embrace_logger_provider.dart';
+import 'package:embrace_platform_interface/embrace_platform_interface.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:plugin_platform_interface/plugin_platform_interface.dart';
+
+class MockEmbracePlatform extends Mock
+    with MockPlatformInterfaceMixin
+    implements EmbracePlatform {}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late MockEmbracePlatform platform;
+
+  setUp(() {
+    platform = MockEmbracePlatform();
+    EmbracePlatform.instance = platform;
+  });
+
+  // ignore: invalid_use_of_visible_for_testing_member
+  tearDown(OTelAPI.reset);
+
+  group('EmbraceLoggerProvider', () {
+    late EmbraceLoggerProvider provider;
+
+    setUp(() {
+      provider = EmbraceLoggerProvider(endpoint: '');
+    });
+
+    test('shutdown() sets isShutdown to true', () async {
+      expect(provider.isShutdown, isFalse);
+
+      await provider.shutdown();
+
+      expect(provider.isShutdown, isTrue);
+    });
+
+    test('shutdown() sets enabled to false', () async {
+      expect(provider.enabled, isTrue);
+
+      await provider.shutdown();
+
+      expect(provider.enabled, isFalse);
+    });
+
+    test('getLogger() returns an APILogger', () {
+      expect(provider.getLogger('test'), isA<APILogger>());
+    });
+
+    group('addLogRecordExporter', () {
+      const endpoint = 'https://collector.example.com/v1/logs';
+
+      test('forwards to platform immediately when already started', () {
+        when(() => platform.isStarted).thenReturn(true);
+        when(
+          () => platform.addLogRecordExporter(
+            endpoint: any(named: 'endpoint'),
+            headers: any(named: 'headers'),
+            timeoutSeconds: any(named: 'timeoutSeconds'),
+          ),
+        ).thenReturn(null);
+
+        provider.addLogRecordExporter(endpoint: endpoint);
+
+        verify(
+          () => platform.addLogRecordExporter(
+            endpoint: endpoint,
+            headers: null,
+            timeoutSeconds: null,
+          ),
+        ).called(1);
+      });
+
+      test('queues exporter when SDK not yet started', () {
+        when(() => platform.isStarted).thenReturn(false);
+        when(
+          () => platform.addLogRecordExporter(
+            endpoint: any(named: 'endpoint'),
+            headers: any(named: 'headers'),
+            timeoutSeconds: any(named: 'timeoutSeconds'),
+          ),
+        ).thenReturn(null);
+
+        provider.addLogRecordExporter(endpoint: endpoint);
+
+        verifyNever(
+          () => platform.addLogRecordExporter(
+            endpoint: any(named: 'endpoint'),
+            headers: any(named: 'headers'),
+            timeoutSeconds: any(named: 'timeoutSeconds'),
+          ),
+        );
+      });
+    });
+
+    group('flushPendingExporters', () {
+      const endpoint = 'https://collector.example.com/v1/logs';
+
+      test('forwards queued exporters to platform', () {
+        when(() => platform.isStarted).thenReturn(false);
+        when(
+          () => platform.addLogRecordExporter(
+            endpoint: any(named: 'endpoint'),
+            headers: any(named: 'headers'),
+            timeoutSeconds: any(named: 'timeoutSeconds'),
+          ),
+        ).thenReturn(null);
+
+        provider.addLogRecordExporter(
+          endpoint: endpoint,
+          headers: [
+            {'X-Api-Key': 'secret'},
+          ],
+          timeoutSeconds: 15,
+        );
+
+        provider.flushPendingExporters();
+
+        verify(
+          () => platform.addLogRecordExporter(
+            endpoint: endpoint,
+            headers: [
+              {'X-Api-Key': 'secret'},
+            ],
+            timeoutSeconds: 15,
+          ),
+        ).called(1);
+      });
+
+      test('clears queue after flush so second flush is a no-op', () {
+        when(() => platform.isStarted).thenReturn(false);
+        when(
+          () => platform.addLogRecordExporter(
+            endpoint: any(named: 'endpoint'),
+            headers: any(named: 'headers'),
+            timeoutSeconds: any(named: 'timeoutSeconds'),
+          ),
+        ).thenReturn(null);
+
+        provider.addLogRecordExporter(endpoint: endpoint);
+        provider.flushPendingExporters();
+        provider.flushPendingExporters();
+
+        verify(
+          () => platform.addLogRecordExporter(
+            endpoint: any(named: 'endpoint'),
+            headers: any(named: 'headers'),
+            timeoutSeconds: any(named: 'timeoutSeconds'),
+          ),
+        ).called(1);
+      });
+    });
+
+    test('resetForTesting() clears pending queue', () {
+      when(() => platform.isStarted).thenReturn(false);
+      when(
+        () => platform.addLogRecordExporter(
+          endpoint: any(named: 'endpoint'),
+          headers: any(named: 'headers'),
+          timeoutSeconds: any(named: 'timeoutSeconds'),
+        ),
+      ).thenReturn(null);
+
+      provider.addLogRecordExporter(
+        endpoint: 'https://collector.example.com/v1/logs',
+      );
+
+      // ignore: invalid_use_of_visible_for_testing_member
+      provider.resetForTesting();
+      provider.flushPendingExporters();
+
+      verifyNever(
+        () => platform.addLogRecordExporter(
+          endpoint: any(named: 'endpoint'),
+          headers: any(named: 'headers'),
+          timeoutSeconds: any(named: 'timeoutSeconds'),
+        ),
+      );
+    });
+  });
+}

--- a/embrace/test/src/otel/logs/embrace_logger_provider_test.dart
+++ b/embrace/test/src/otel/logs/embrace_logger_provider_test.dart
@@ -68,8 +68,8 @@ void main() {
         verify(
           () => platform.addLogRecordExporter(
             endpoint: endpoint,
-            headers: null,
-            timeoutSeconds: null,
+            headers: any(named: 'headers'),
+            timeoutSeconds: any(named: 'timeoutSeconds'),
           ),
         ).called(1);
       });
@@ -109,15 +109,15 @@ void main() {
           ),
         ).thenReturn(null);
 
-        provider.addLogRecordExporter(
-          endpoint: endpoint,
-          headers: [
-            {'X-Api-Key': 'secret'},
-          ],
-          timeoutSeconds: 15,
-        );
-
-        provider.flushPendingExporters();
+        provider
+          ..addLogRecordExporter(
+            endpoint: endpoint,
+            headers: [
+              {'X-Api-Key': 'secret'},
+            ],
+            timeoutSeconds: 15,
+          )
+          ..flushPendingExporters();
 
         verify(
           () => platform.addLogRecordExporter(
@@ -140,9 +140,10 @@ void main() {
           ),
         ).thenReturn(null);
 
-        provider.addLogRecordExporter(endpoint: endpoint);
-        provider.flushPendingExporters();
-        provider.flushPendingExporters();
+        provider
+          ..addLogRecordExporter(endpoint: endpoint)
+          ..flushPendingExporters()
+          ..flushPendingExporters();
 
         verify(
           () => platform.addLogRecordExporter(
@@ -152,6 +153,33 @@ void main() {
           ),
         ).called(1);
       });
+    });
+
+    test('flushes multiple queued exporters in order', () {
+      when(() => platform.isStarted).thenReturn(false);
+
+      final callOrder = <String>[];
+      when(
+        () => platform.addLogRecordExporter(
+          endpoint: 'https://first.example.com',
+          headers: any(named: 'headers'),
+          timeoutSeconds: any(named: 'timeoutSeconds'),
+        ),
+      ).thenAnswer((_) => callOrder.add('first'));
+      when(
+        () => platform.addLogRecordExporter(
+          endpoint: 'https://second.example.com',
+          headers: any(named: 'headers'),
+          timeoutSeconds: any(named: 'timeoutSeconds'),
+        ),
+      ).thenAnswer((_) => callOrder.add('second'));
+
+      provider
+        ..addLogRecordExporter(endpoint: 'https://first.example.com')
+        ..addLogRecordExporter(endpoint: 'https://second.example.com')
+        ..flushPendingExporters();
+
+      expect(callOrder, ['first', 'second']);
     });
 
     test('resetForTesting() clears pending queue', () {
@@ -164,13 +192,13 @@ void main() {
         ),
       ).thenReturn(null);
 
-      provider.addLogRecordExporter(
-        endpoint: 'https://collector.example.com/v1/logs',
-      );
-
       // ignore: invalid_use_of_visible_for_testing_member
-      provider.resetForTesting();
-      provider.flushPendingExporters();
+      provider
+        ..addLogRecordExporter(
+          endpoint: 'https://collector.example.com/v1/logs',
+        )
+        ..resetForTesting()
+        ..flushPendingExporters();
 
       verifyNever(
         () => platform.addLogRecordExporter(

--- a/embrace/test/src/otel/tracing/embrace_tracer_provider_test.dart
+++ b/embrace/test/src/otel/tracing/embrace_tracer_provider_test.dart
@@ -88,8 +88,8 @@ void main() {
         verify(
           () => platform.addSpanExporter(
             endpoint: endpoint,
-            headers: null,
-            timeoutSeconds: null,
+            headers: any(named: 'headers'),
+            timeoutSeconds: any(named: 'timeoutSeconds'),
           ),
         ).called(1);
       });
@@ -108,14 +108,14 @@ void main() {
 
       // Call before start — platform is not yet started
       when(() => platform.isStarted).thenReturn(false);
-      final provider = EmbraceTracerProvider(endpoint: '');
-      provider.addSpanExporter(
-        endpoint: 'https://collector.example.com/v1/traces',
-        headers: [
-          {'Authorization': 'Bearer tok'},
-        ],
-        timeoutSeconds: 30,
-      );
+      final provider = EmbraceTracerProvider(endpoint: '')
+        ..addSpanExporter(
+          endpoint: 'https://collector.example.com/v1/traces',
+          headers: [
+            {'Authorization': 'Bearer tok'},
+          ],
+          timeoutSeconds: 30,
+        );
 
       // Platform not called yet
       verifyNever(
@@ -140,14 +140,50 @@ void main() {
       ).called(1);
     });
 
-    test('resetForTesting() clears pending queue', () {
+    test('flushes multiple queued exporters in order', () {
+      when(
+        () => platform.addSpanExporter(
+          endpoint: any(named: 'endpoint'),
+          headers: any(named: 'headers'),
+          timeoutSeconds: any(named: 'timeoutSeconds'),
+        ),
+      ).thenReturn(null);
+
       when(() => platform.isStarted).thenReturn(false);
       final provider = EmbraceTracerProvider(endpoint: '');
-      provider.addSpanExporter(endpoint: 'https://collector.example.com');
+
+      final callOrder = <String>[];
+      when(
+        () => platform.addSpanExporter(
+          endpoint: 'https://first.example.com',
+          headers: any(named: 'headers'),
+          timeoutSeconds: any(named: 'timeoutSeconds'),
+        ),
+      ).thenAnswer((_) => callOrder.add('first'));
+      when(
+        () => platform.addSpanExporter(
+          endpoint: 'https://second.example.com',
+          headers: any(named: 'headers'),
+          timeoutSeconds: any(named: 'timeoutSeconds'),
+        ),
+      ).thenAnswer((_) => callOrder.add('second'));
+
+      provider
+        ..addSpanExporter(endpoint: 'https://first.example.com')
+        ..addSpanExporter(endpoint: 'https://second.example.com')
+        ..flushPendingExporters();
+
+      expect(callOrder, ['first', 'second']);
+    });
+
+    test('resetForTesting() clears pending queue', () {
+      when(() => platform.isStarted).thenReturn(false);
 
       // ignore: invalid_use_of_visible_for_testing_member
-      provider.resetForTesting();
-      provider.flushPendingExporters();
+      EmbraceTracerProvider(endpoint: '')
+        ..addSpanExporter(endpoint: 'https://collector.example.com')
+        ..resetForTesting()
+        ..flushPendingExporters();
 
       verifyNever(
         () => platform.addSpanExporter(

--- a/embrace/test/src/otel/tracing/embrace_tracer_provider_test.dart
+++ b/embrace/test/src/otel/tracing/embrace_tracer_provider_test.dart
@@ -69,5 +69,93 @@ void main() {
 
       expect(provider.enabled, isFalse);
     });
+
+    group('addSpanExporter', () {
+      const endpoint = 'https://collector.example.com/v1/traces';
+
+      test('forwards to platform immediately when already started', () {
+        when(() => platform.isStarted).thenReturn(true);
+        when(
+          () => platform.addSpanExporter(
+            endpoint: any(named: 'endpoint'),
+            headers: any(named: 'headers'),
+            timeoutSeconds: any(named: 'timeoutSeconds'),
+          ),
+        ).thenReturn(null);
+
+        provider.addSpanExporter(endpoint: endpoint);
+
+        verify(
+          () => platform.addSpanExporter(
+            endpoint: endpoint,
+            headers: null,
+            timeoutSeconds: null,
+          ),
+        ).called(1);
+      });
+    });
+  });
+
+  group('EmbraceTracerProvider pre-start queueing', () {
+    test('queues exporter and flushes it when SDK starts', () async {
+      when(
+        () => platform.addSpanExporter(
+          endpoint: any(named: 'endpoint'),
+          headers: any(named: 'headers'),
+          timeoutSeconds: any(named: 'timeoutSeconds'),
+        ),
+      ).thenReturn(null);
+
+      // Call before start — platform is not yet started
+      when(() => platform.isStarted).thenReturn(false);
+      final provider = EmbraceTracerProvider(endpoint: '');
+      provider.addSpanExporter(
+        endpoint: 'https://collector.example.com/v1/traces',
+        headers: [
+          {'Authorization': 'Bearer tok'},
+        ],
+        timeoutSeconds: 30,
+      );
+
+      // Platform not called yet
+      verifyNever(
+        () => platform.addSpanExporter(
+          endpoint: any(named: 'endpoint'),
+          headers: any(named: 'headers'),
+          timeoutSeconds: any(named: 'timeoutSeconds'),
+        ),
+      );
+
+      // Flush — simulates what _start() does
+      provider.flushPendingExporters();
+
+      verify(
+        () => platform.addSpanExporter(
+          endpoint: 'https://collector.example.com/v1/traces',
+          headers: [
+            {'Authorization': 'Bearer tok'},
+          ],
+          timeoutSeconds: 30,
+        ),
+      ).called(1);
+    });
+
+    test('resetForTesting() clears pending queue', () {
+      when(() => platform.isStarted).thenReturn(false);
+      final provider = EmbraceTracerProvider(endpoint: '');
+      provider.addSpanExporter(endpoint: 'https://collector.example.com');
+
+      // ignore: invalid_use_of_visible_for_testing_member
+      provider.resetForTesting();
+      provider.flushPendingExporters();
+
+      verifyNever(
+        () => platform.addSpanExporter(
+          endpoint: any(named: 'endpoint'),
+          headers: any(named: 'headers'),
+          timeoutSeconds: any(named: 'timeoutSeconds'),
+        ),
+      );
+    });
   });
 }

--- a/embrace_android/android/build.gradle
+++ b/embrace_android/android/build.gradle
@@ -31,4 +31,6 @@ dependencies {
   compileOnly "io.embrace:embrace-android-sdk:$embAndroidSdk"
   compileOnly "io.embrace:embrace-android-core:$embAndroidSdk"
   compileOnly "io.embrace:embrace-internal-api:$embAndroidSdk"
+  compileOnly "io.embrace:embrace-android-otel-java:$embAndroidSdk"
+  compileOnly "io.opentelemetry:opentelemetry-exporter-otlp:1.46.0"
 }

--- a/embrace_android/android/src/main/kotlin/io/embrace/flutter/EmbracePlugin.kt
+++ b/embrace_android/android/src/main/kotlin/io/embrace/flutter/EmbracePlugin.kt
@@ -19,6 +19,11 @@ import io.embrace.android.embracesdk.network.EmbraceNetworkRequest
 import io.embrace.android.embracesdk.spans.EmbraceSpan
 import io.embrace.android.embracesdk.spans.ErrorCode
 import io.embrace.android.embracesdk.spans.EmbraceSpanEvent
+import io.embrace.android.embracesdk.otel.java.addJavaLogRecordExporter
+import io.embrace.android.embracesdk.otel.java.addJavaSpanExporter
+import io.opentelemetry.exporter.otlp.http.logs.OtlpHttpLogRecordExporter
+import io.opentelemetry.exporter.otlp.http.trace.OtlpHttpSpanExporter
+import java.util.concurrent.TimeUnit
 
 import android.os.Handler
 import android.os.Looper
@@ -68,6 +73,8 @@ internal object EmbraceConstants {
     internal const val ADD_SPAN_ATTRIBUTE_METHOD_NAME : String = "addSpanAttribute"
     internal const val RECORD_COMPLETED_SPAN_METHOD_NAME : String = "recordCompletedSpan"
     internal const val GET_TRACE_ID_METHOD_NAME : String = "getTraceId"
+    internal const val ADD_SPAN_EXPORTER_METHOD_NAME : String = "addSpanExporter"
+    internal const val ADD_LOG_RECORD_EXPORTER_METHOD_NAME : String = "addLogRecordExporter"
 
     // Parameter Names
     internal const val ENABLE_INTEGRATION_TESTING_ARG_NAME : String = "enableIntegrationTesting"
@@ -117,6 +124,9 @@ internal object EmbraceConstants {
     internal const val TIMESTAMP_MS_ARG_NAME : String = "timestampMs"
     internal const val ATTRIBUTES_ARG_NAME : String = "attributes"
     internal const val EVENTS_ARG_NAME : String = "events"
+    internal const val ENDPOINT_ARG_NAME : String = "endpoint"
+    internal const val HEADERS_ARG_NAME : String = "headers"
+    internal const val TIMEOUT_SECONDS_ARG_NAME : String = "timeoutSeconds"
 }
 
 /**
@@ -184,6 +194,8 @@ public class EmbracePlugin : FlutterPlugin, MethodCallHandler {
                 EmbraceConstants.ADD_SPAN_ATTRIBUTE_METHOD_NAME -> handleAddSpanAttribute(call, result)
                 EmbraceConstants.RECORD_COMPLETED_SPAN_METHOD_NAME -> handleRecordCompletedSpan(call, result)
                 EmbraceConstants.GET_TRACE_ID_METHOD_NAME -> handleGetTraceId(call, result)
+                EmbraceConstants.ADD_SPAN_EXPORTER_METHOD_NAME -> handleAddSpanExporter(call, result)
+                EmbraceConstants.ADD_LOG_RECORD_EXPORTER_METHOD_NAME -> handleAddLogRecordExporter(call, result)
                 else -> {
                     result.notImplemented()
                     throw NotImplementedError("EmbracePlugin received a method call for ${call.method} but has no handler for that name.")
@@ -714,6 +726,52 @@ public class EmbracePlugin : FlutterPlugin, MethodCallHandler {
             span?.traceId
         }
         result.success(traceId)
+    }
+
+    private fun handleAddSpanExporter(call: MethodCall, result: Result) {
+        val endpoint = call.getStringArgument(EmbraceConstants.ENDPOINT_ARG_NAME)
+        if (endpoint.isEmpty()) {
+            result.success(null)
+            return
+        }
+        try {
+            val builder = OtlpHttpSpanExporter.builder().setEndpoint(endpoint)
+            val headers = call.getListArgument<Map<String, String>>(EmbraceConstants.HEADERS_ARG_NAME)
+            headers.forEach { header ->
+                val key = header["key"]
+                val token = header["token"]
+                if (key != null && token != null) {
+                    builder.addHeader(key, token)
+                }
+            }
+            val timeoutSeconds: Int? = call.argument(EmbraceConstants.TIMEOUT_SECONDS_ARG_NAME)
+            timeoutSeconds?.let { builder.setTimeout(it.toLong(), TimeUnit.SECONDS) }
+            Embrace.addJavaSpanExporter(builder.build())
+        } catch (_: Throwable) {}
+        result.success(null)
+    }
+
+    private fun handleAddLogRecordExporter(call: MethodCall, result: Result) {
+        val endpoint = call.getStringArgument(EmbraceConstants.ENDPOINT_ARG_NAME)
+        if (endpoint.isEmpty()) {
+            result.success(null)
+            return
+        }
+        try {
+            val builder = OtlpHttpLogRecordExporter.builder().setEndpoint(endpoint)
+            val headers = call.getListArgument<Map<String, String>>(EmbraceConstants.HEADERS_ARG_NAME)
+            headers.forEach { header ->
+                val key = header["key"]
+                val token = header["token"]
+                if (key != null && token != null) {
+                    builder.addHeader(key, token)
+                }
+            }
+            val timeoutSeconds: Int? = call.argument(EmbraceConstants.TIMEOUT_SECONDS_ARG_NAME)
+            timeoutSeconds?.let { builder.setTimeout(it.toLong(), TimeUnit.SECONDS) }
+            Embrace.addJavaLogRecordExporter(builder.build())
+        } catch (_: Throwable) {}
+        result.success(null)
     }
 
     private fun mapToEvent(map: Map<String, Any>): EmbraceSpanEvent? {

--- a/embrace_android/android/src/main/kotlin/io/embrace/flutter/EmbracePlugin.kt
+++ b/embrace_android/android/src/main/kotlin/io/embrace/flutter/EmbracePlugin.kt
@@ -738,11 +738,7 @@ public class EmbracePlugin : FlutterPlugin, MethodCallHandler {
             val builder = OtlpHttpSpanExporter.builder().setEndpoint(endpoint)
             val headers = call.getListArgument<Map<String, String>>(EmbraceConstants.HEADERS_ARG_NAME)
             headers.forEach { header ->
-                val key = header["key"]
-                val token = header["token"]
-                if (key != null && token != null) {
-                    builder.addHeader(key, token)
-                }
+                header.forEach { (key, value) -> builder.addHeader(key, value) }
             }
             val timeoutSeconds: Int? = call.argument(EmbraceConstants.TIMEOUT_SECONDS_ARG_NAME)
             timeoutSeconds?.let { builder.setTimeout(it.toLong(), TimeUnit.SECONDS) }
@@ -761,11 +757,7 @@ public class EmbracePlugin : FlutterPlugin, MethodCallHandler {
             val builder = OtlpHttpLogRecordExporter.builder().setEndpoint(endpoint)
             val headers = call.getListArgument<Map<String, String>>(EmbraceConstants.HEADERS_ARG_NAME)
             headers.forEach { header ->
-                val key = header["key"]
-                val token = header["token"]
-                if (key != null && token != null) {
-                    builder.addHeader(key, token)
-                }
+                header.forEach { (key, value) -> builder.addHeader(key, value) }
             }
             val timeoutSeconds: Int? = call.argument(EmbraceConstants.TIMEOUT_SECONDS_ARG_NAME)
             timeoutSeconds?.let { builder.setTimeout(it.toLong(), TimeUnit.SECONDS) }

--- a/embrace_android/android/src/main/kotlin/io/embrace/flutter/EmbracePlugin.kt
+++ b/embrace_android/android/src/main/kotlin/io/embrace/flutter/EmbracePlugin.kt
@@ -743,7 +743,9 @@ public class EmbracePlugin : FlutterPlugin, MethodCallHandler {
             val timeoutSeconds: Int? = call.argument(EmbraceConstants.TIMEOUT_SECONDS_ARG_NAME)
             timeoutSeconds?.let { builder.setTimeout(it.toLong(), TimeUnit.SECONDS) }
             Embrace.addJavaSpanExporter(builder.build())
-        } catch (_: Throwable) {}
+        } catch (e: Throwable) {
+            Log.w("EmbraceFlutter", "Failed to add span exporter: ${e.message}", e)
+        }
         result.success(null)
     }
 
@@ -762,7 +764,9 @@ public class EmbracePlugin : FlutterPlugin, MethodCallHandler {
             val timeoutSeconds: Int? = call.argument(EmbraceConstants.TIMEOUT_SECONDS_ARG_NAME)
             timeoutSeconds?.let { builder.setTimeout(it.toLong(), TimeUnit.SECONDS) }
             Embrace.addJavaLogRecordExporter(builder.build())
-        } catch (_: Throwable) {}
+        } catch (e: Throwable) {
+            Log.w("EmbraceFlutter", "Failed to add log record exporter: ${e.message}", e)
+        }
         result.success(null)
     }
 

--- a/embrace_ios/ios/Classes/EmbracePlugin.swift
+++ b/embrace_ios/ios/Classes/EmbracePlugin.swift
@@ -47,6 +47,8 @@ public class EmbracePlugin: NSObject, FlutterPlugin {
     static let RecordCompletedSpanMethodName = "recordCompletedSpan"
     static let GenerateW3cTraceparentMethodName = "generateW3cTraceparent"
     static let GetTraceIdMethodName = "getTraceId"
+    static let AddSpanExporterMethodName = "addSpanExporter"
+    static let AddLogRecordExporterMethodName = "addLogRecordExporter"
 
     // Parameter Names
     static let PropertiesArgName = "properties"
@@ -94,6 +96,9 @@ public class EmbracePlugin: NSObject, FlutterPlugin {
     static let AttributesArgName = "attributes"
     static let EventsArgName = "events"
     static let W3cTraceparentArgName = "traceParent"
+    static let EndpointArgName = "endpoint"
+    static let HeadersArgName = "headers"
+    static let TimeoutSecondsArgName = "timeoutSeconds"
 
     // OTel keys
     static let SpanScreenView = "emb-screen-view"
@@ -202,6 +207,10 @@ public class EmbracePlugin: NSObject, FlutterPlugin {
                 handleGenerateW3cTraceparentCall(call, result: result)
             case EmbracePlugin.GetTraceIdMethodName:
                 handleGetTraceIdCall(call, result: result)
+            case EmbracePlugin.AddSpanExporterMethodName:
+                handleAddSpanExporterCall(call, result: result)
+            case EmbracePlugin.AddLogRecordExporterMethodName:
+                handleAddLogRecordExporterCall(call, result: result)
             default:
                 result(FlutterMethodNotImplemented)
         }
@@ -676,6 +685,19 @@ public class EmbracePlugin: NSObject, FlutterPlugin {
                 result(nil)
             }
         }
+    }
+
+    private func handleAddSpanExporterCall(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
+        // OTLP HTTP span exporter configuration is not yet supported at runtime
+        // on iOS. The native EmbraceIO SDK configures exporters at startup via
+        // options; runtime addition will be supported in a future SDK release.
+        result(nil)
+    }
+
+    private func handleAddLogRecordExporterCall(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
+        // OTLP HTTP log record exporter configuration is not yet supported at
+        // runtime on iOS. See handleAddSpanExporterCall for details.
+        result(nil)
     }
 
     private func callAppleSdk<T>(action: (Embrace) -> T) -> T? {

--- a/embrace_platform_interface/lib/embrace_platform_interface.dart
+++ b/embrace_platform_interface/lib/embrace_platform_interface.dart
@@ -410,4 +410,26 @@ abstract class EmbracePlatform extends PlatformInterface {
   ) {
     throw UnimplementedError('addSpanLink() has not been implemented');
   }
+
+  /// Configures an OTLP HTTP span exporter on the native SDK.
+  ///
+  /// May be called before or after [attachToHostSdk].
+  void addSpanExporter({
+    required String endpoint,
+    List<Map<String, String>>? headers,
+    int? timeoutSeconds,
+  }) {
+    throw UnimplementedError('addSpanExporter() has not been implemented');
+  }
+
+  /// Configures an OTLP HTTP log record exporter on the native SDK.
+  ///
+  /// May be called before or after [attachToHostSdk].
+  void addLogRecordExporter({
+    required String endpoint,
+    List<Map<String, String>>? headers,
+    int? timeoutSeconds,
+  }) {
+    throw UnimplementedError('addLogRecordExporter() has not been implemented');
+  }
 }

--- a/embrace_platform_interface/lib/method_channel_embrace.dart
+++ b/embrace_platform_interface/lib/method_channel_embrace.dart
@@ -58,6 +58,8 @@ class MethodChannelEmbrace extends EmbracePlatform {
   static const String _setSpanStatusMethodName = 'setSpanStatus';
   static const String _updateSpanNameMethodName = 'updateSpanName';
   static const String _addSpanLinkMethodName = 'addSpanLink';
+  static const String _addSpanExporterMethodName = 'addSpanExporter';
+  static const String _addLogRecordExporterMethodName = 'addLogRecordExporter';
 
   // Parameter Names
   static const String _propertiesArgName = 'properties';
@@ -114,6 +116,9 @@ class MethodChannelEmbrace extends EmbracePlatform {
   static const String _descriptionArgName = 'description';
   static const String _linkedTraceIdArgName = 'linkedTraceId';
   static const String _linkedSpanIdArgName = 'linkedSpanId';
+  static const String _endpointArgName = 'endpoint';
+  static const String _headersArgName = 'headers';
+  static const String _timeoutSecondsArgName = 'timeoutSeconds';
 
   /// Minimum Embrace Android SDK version compatible with this version of
   /// the Embrace Flutter SDK
@@ -670,6 +675,32 @@ class MethodChannelEmbrace extends EmbracePlatform {
       _linkedSpanIdArgName: linkedSpanId,
       _attributesArgName: attributes,
     }) as bool;
+  }
+
+  @override
+  void addSpanExporter({
+    required String endpoint,
+    List<Map<String, String>>? headers,
+    int? timeoutSeconds,
+  }) {
+    methodChannel.invokeMethod(_addSpanExporterMethodName, {
+      _endpointArgName: endpoint,
+      _headersArgName: headers,
+      _timeoutSecondsArgName: timeoutSeconds,
+    });
+  }
+
+  @override
+  void addLogRecordExporter({
+    required String endpoint,
+    List<Map<String, String>>? headers,
+    int? timeoutSeconds,
+  }) {
+    methodChannel.invokeMethod(_addLogRecordExporterMethodName, {
+      _endpointArgName: endpoint,
+      _headersArgName: headers,
+      _timeoutSecondsArgName: timeoutSeconds,
+    });
   }
 
   /// Throws a [StateError] if the SDK has not been started.

--- a/embrace_platform_interface/test/src/method_channel_embrace_test.dart
+++ b/embrace_platform_interface/test/src/method_channel_embrace_test.dart
@@ -1411,5 +1411,109 @@ void main() {
         expect(log, isEmpty);
       });
     });
+
+    group('addSpanExporter', () {
+      const endpoint = 'https://collector.example.com/v1/traces';
+      final headers = [
+        {'Authorization': 'Bearer token123'},
+      ];
+      const timeoutSeconds = 30;
+
+      test('invokes addSpanExporter with all arguments', () async {
+        await methodChannelEmbrace.attachToHostSdk(
+          enableIntegrationTesting: false,
+        );
+        methodChannelEmbrace.addSpanExporter(
+          endpoint: endpoint,
+          headers: headers,
+          timeoutSeconds: timeoutSeconds,
+        );
+        expect(
+          log,
+          contains(
+            isMethodCall(
+              'addSpanExporter',
+              arguments: {
+                'endpoint': endpoint,
+                'headers': headers,
+                'timeoutSeconds': timeoutSeconds,
+              },
+            ),
+          ),
+        );
+      });
+
+      test('invokes addSpanExporter with only required argument', () async {
+        await methodChannelEmbrace.attachToHostSdk(
+          enableIntegrationTesting: false,
+        );
+        methodChannelEmbrace.addSpanExporter(endpoint: endpoint);
+        expect(
+          log,
+          contains(
+            isMethodCall(
+              'addSpanExporter',
+              arguments: {
+                'endpoint': endpoint,
+                'headers': null,
+                'timeoutSeconds': null,
+              },
+            ),
+          ),
+        );
+      });
+    });
+
+    group('addLogRecordExporter', () {
+      const endpoint = 'https://collector.example.com/v1/logs';
+      final headers = [
+        {'Authorization': 'Bearer token456'},
+      ];
+      const timeoutSeconds = 60;
+
+      test('invokes addLogRecordExporter with all arguments', () async {
+        await methodChannelEmbrace.attachToHostSdk(
+          enableIntegrationTesting: false,
+        );
+        methodChannelEmbrace.addLogRecordExporter(
+          endpoint: endpoint,
+          headers: headers,
+          timeoutSeconds: timeoutSeconds,
+        );
+        expect(
+          log,
+          contains(
+            isMethodCall(
+              'addLogRecordExporter',
+              arguments: {
+                'endpoint': endpoint,
+                'headers': headers,
+                'timeoutSeconds': timeoutSeconds,
+              },
+            ),
+          ),
+        );
+      });
+
+      test('invokes addLogRecordExporter with only required argument', () async {
+        await methodChannelEmbrace.attachToHostSdk(
+          enableIntegrationTesting: false,
+        );
+        methodChannelEmbrace.addLogRecordExporter(endpoint: endpoint);
+        expect(
+          log,
+          contains(
+            isMethodCall(
+              'addLogRecordExporter',
+              arguments: {
+                'endpoint': endpoint,
+                'headers': null,
+                'timeoutSeconds': null,
+              },
+            ),
+          ),
+        );
+      });
+    });
   });
 }

--- a/embrace_platform_interface/test/src/method_channel_embrace_test.dart
+++ b/embrace_platform_interface/test/src/method_channel_embrace_test.dart
@@ -1495,7 +1495,8 @@ void main() {
         );
       });
 
-      test('invokes addLogRecordExporter with only required argument', () async {
+      test('invokes addLogRecordExporter with only required argument',
+          () async {
         await methodChannelEmbrace.attachToHostSdk(
           enableIntegrationTesting: false,
         );


### PR DESCRIPTION
Adds OTLP HTTP exporter configuration to EmbraceTracerProvider and
EmbraceLoggerProvider. Calls made before Embrace.start() are queued in
Dart and flushed after attachToHostSdk. Android wires up
OtlpHttpSpanExporter / OtlpHttpLogRecordExporter via the embrace-android-otel-java
extension; iOS handlers are no-ops (EmbraceIO 6.x does not support
runtime exporter addition).