### PR TITLE
feat(otel): implement EmbraceLoggerProvider and EmbraceLogger

### DIFF
--- a/embrace/lib/src/otel/logs/embrace_logger.dart
+++ b/embrace/lib/src/otel/logs/embrace_logger.dart
@@ -1,0 +1,64 @@
+import 'package:dartastic_opentelemetry_api/dartastic_opentelemetry_api.dart';
+import 'package:embrace/src/otel/logs/embrace_logger_provider.dart';
+import 'package:embrace_platform_interface/embrace_platform_interface.dart';
+import 'package:meta/meta.dart';
+
+/// Embrace implementation of [APILogger].
+///
+/// Delegates [emit] to the native Embrace log methods by mapping the OTel
+/// severity number to [EmbracePlatform.logInfo], [EmbracePlatform.logWarning],
+/// or [EmbracePlatform.logError]. Attributes, timestamps, and event name are
+/// accepted but not forwarded in v1.
+@internal
+class EmbraceLogger implements APILogger {
+  /// Creates an [EmbraceLogger].
+  EmbraceLogger({
+    required this.name,
+    required EmbraceLoggerProvider provider,
+    this.version,
+    this.schemaUrl,
+    this.attributes,
+  }) : _provider = provider;
+
+  final EmbraceLoggerProvider _provider;
+
+  @override
+  final String name;
+
+  @override
+  final String? version;
+
+  @override
+  final String? schemaUrl;
+
+  @override
+  final Attributes? attributes;
+
+  @override
+  bool get enabled => _provider.enabled;
+
+  @override
+  void emit({
+    DateTime? timeStamp,
+    DateTime? observedTimestamp,
+    Context? context,
+    Severity? severityNumber,
+    String? severityText,
+    dynamic body,
+    Attributes? attributes,
+    String? eventName,
+  }) {
+    if (!enabled) return;
+
+    final message = body?.toString() ?? '';
+    final sev = severityNumber?.severityNumber ?? 0;
+
+    if (sev >= 17) {
+      EmbracePlatform.instance.logError(message, null);
+    } else if (sev >= 13) {
+      EmbracePlatform.instance.logWarning(message, null);
+    } else {
+      EmbracePlatform.instance.logInfo(message, null);
+    }
+  }
+}

--- a/embrace/lib/src/otel/logs/embrace_logger.dart
+++ b/embrace/lib/src/otel/logs/embrace_logger.dart
@@ -3,6 +3,10 @@ import 'package:embrace/src/otel/logs/embrace_logger_provider.dart';
 import 'package:embrace_platform_interface/embrace_platform_interface.dart';
 import 'package:meta/meta.dart';
 
+// OTel Log Data Model severity number range boundaries (spec §10.5.2).
+const int _kWarnSeverityMin = 13;
+const int _kErrorSeverityMin = 17;
+
 /// Embrace implementation of [APILogger].
 ///
 /// Delegates [emit] to the native Embrace log methods by mapping the OTel
@@ -53,9 +57,9 @@ class EmbraceLogger implements APILogger {
     final message = body?.toString() ?? '';
     final sev = severityNumber?.severityNumber ?? 0;
 
-    if (sev >= 17) {
+    if (sev >= _kErrorSeverityMin) {
       EmbracePlatform.instance.logError(message, null);
-    } else if (sev >= 13) {
+    } else if (sev >= _kWarnSeverityMin) {
       EmbracePlatform.instance.logWarning(message, null);
     } else {
       EmbracePlatform.instance.logInfo(message, null);

--- a/embrace/lib/src/otel/logs/embrace_logger_provider.dart
+++ b/embrace/lib/src/otel/logs/embrace_logger_provider.dart
@@ -1,4 +1,5 @@
 import 'package:dartastic_opentelemetry_api/dartastic_opentelemetry_api.dart';
+import 'package:embrace/src/otel/logs/embrace_logger.dart';
 import 'package:embrace_platform_interface/embrace_platform_interface.dart';
 import 'package:meta/meta.dart';
 
@@ -34,6 +35,7 @@ class EmbraceLoggerProvider implements APILoggerProvider {
   bool _isShutdown;
 
   final List<_LogExporterConfig> _pendingLogExporters = [];
+  final Map<String, EmbraceLogger> _loggerCache = {};
 
   /// Adds an OTLP HTTP log record exporter.
   ///
@@ -81,23 +83,30 @@ class EmbraceLoggerProvider implements APILoggerProvider {
   // ── APILoggerProvider interface ──────────────────────────────────────────
 
   @override
-  APILogger getLogger(
+  EmbraceLogger getLogger(
     String name, {
     String? version,
     String? schemaUrl,
     Attributes? attributes,
-  }) =>
-      LoggerCreate.create(
+  }) {
+    final key = '$name:$version';
+    return _loggerCache.putIfAbsent(
+      key,
+      () => EmbraceLogger(
         name: name,
+        provider: this,
         version: version,
         schemaUrl: schemaUrl,
         attributes: attributes,
-      );
+      ),
+    );
+  }
 
   @override
   Future<bool> shutdown() async {
     _isShutdown = true;
     _enabled = false;
+    _loggerCache.clear();
     return true;
   }
 

--- a/embrace/test/src/otel/logs/embrace_logger_provider_test.dart
+++ b/embrace/test/src/otel/logs/embrace_logger_provider_test.dart
@@ -1,4 +1,7 @@
 import 'package:dartastic_opentelemetry_api/dartastic_opentelemetry_api.dart';
+import 'package:embrace/embrace.dart';
+// ignore: implementation_imports
+import 'package:embrace/src/otel/logs/embrace_logger.dart';
 // ignore: implementation_imports
 import 'package:embrace/src/otel/logs/embrace_logger_provider.dart';
 import 'package:embrace_platform_interface/embrace_platform_interface.dart';
@@ -18,6 +21,11 @@ void main() {
   setUp(() {
     platform = MockEmbracePlatform();
     EmbracePlatform.instance = platform;
+    when(
+      () => platform.attachToHostSdk(
+        enableIntegrationTesting: any(named: 'enableIntegrationTesting'),
+      ),
+    ).thenAnswer((_) async => true);
   });
 
   // ignore: invalid_use_of_visible_for_testing_member
@@ -46,8 +54,26 @@ void main() {
       expect(provider.enabled, isFalse);
     });
 
-    test('getLogger() returns an APILogger', () {
-      expect(provider.getLogger('test'), isA<APILogger>());
+    test('getLogger() returns an EmbraceLogger', () {
+      expect(provider.getLogger('test'), isA<EmbraceLogger>());
+    });
+
+    test('repeated getLogger() calls with same name return same instance', () {
+      final first = provider.getLogger('foo');
+      final second = provider.getLogger('foo');
+
+      expect(identical(first, second), isTrue);
+    });
+
+    group('OTelAPI integration', () {
+      test('getLogger() via OTelAPI returns EmbraceLogger', () async {
+        await Embrace.instance.start();
+
+        expect(
+          OTelAPI.loggerProvider().getLogger('foo'),
+          isA<EmbraceLogger>(),
+        );
+      });
     });
 
     group('addLogRecordExporter', () {

--- a/embrace/test/src/otel/logs/embrace_logger_test.dart
+++ b/embrace/test/src/otel/logs/embrace_logger_test.dart
@@ -1,0 +1,100 @@
+import 'package:dartastic_opentelemetry_api/dartastic_opentelemetry_api.dart';
+// ignore: implementation_imports
+import 'package:embrace/src/otel/logs/embrace_logger.dart';
+// ignore: implementation_imports
+import 'package:embrace/src/otel/logs/embrace_logger_provider.dart';
+import 'package:embrace_platform_interface/embrace_platform_interface.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:plugin_platform_interface/plugin_platform_interface.dart';
+
+class MockEmbracePlatform extends Mock
+    with MockPlatformInterfaceMixin
+    implements EmbracePlatform {}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late MockEmbracePlatform platform;
+  late EmbraceLoggerProvider provider;
+  late EmbraceLogger logger;
+
+  setUp(() {
+    platform = MockEmbracePlatform();
+    EmbracePlatform.instance = platform;
+
+    when(
+      () => platform.logInfo(any(), any()),
+    ).thenReturn(null);
+    when(
+      () => platform.logWarning(any(), any()),
+    ).thenReturn(null);
+    when(
+      () => platform.logError(any(), any()),
+    ).thenReturn(null);
+
+    provider = EmbraceLoggerProvider(endpoint: '');
+    logger = provider.getLogger('test');
+  });
+
+  // ignore: invalid_use_of_visible_for_testing_member
+  tearDown(OTelAPI.reset);
+
+  group('EmbraceLogger', () {
+    test('emit with severity 5 (DEBUG) calls logInfo', () {
+      logger.emit(severityNumber: Severity.DEBUG, body: 'debug msg');
+
+      verify(() => platform.logInfo('debug msg', null)).called(1);
+      verifyNever(() => platform.logWarning(any(), any()));
+      verifyNever(() => platform.logError(any(), any()));
+    });
+
+    test('emit with severity 9 (INFO) calls logInfo', () {
+      logger.emit(severityNumber: Severity.INFO, body: 'info msg');
+
+      verify(() => platform.logInfo('info msg', null)).called(1);
+      verifyNever(() => platform.logWarning(any(), any()));
+      verifyNever(() => platform.logError(any(), any()));
+    });
+
+    test('emit with severity 13 (WARN) calls logWarning', () {
+      logger.emit(severityNumber: Severity.WARN, body: 'warn msg');
+
+      verify(() => platform.logWarning('warn msg', null)).called(1);
+      verifyNever(() => platform.logInfo(any(), any()));
+      verifyNever(() => platform.logError(any(), any()));
+    });
+
+    test('emit with severity 17 (ERROR) calls logError', () {
+      logger.emit(severityNumber: Severity.ERROR, body: 'error msg');
+
+      verify(() => platform.logError('error msg', null)).called(1);
+      verifyNever(() => platform.logInfo(any(), any()));
+      verifyNever(() => platform.logWarning(any(), any()));
+    });
+
+    test('emit with severity 21 (FATAL) calls logError', () {
+      logger.emit(severityNumber: Severity.FATAL, body: 'fatal msg');
+
+      verify(() => platform.logError('fatal msg', null)).called(1);
+      verifyNever(() => platform.logInfo(any(), any()));
+      verifyNever(() => platform.logWarning(any(), any()));
+    });
+
+    test('emit forwards body as message string', () {
+      logger.emit(severityNumber: Severity.INFO, body: 'the message');
+
+      verify(() => platform.logInfo('the message', null)).called(1);
+    });
+
+    test('emit when enabled is false is a no-op', () async {
+      await provider.shutdown();
+
+      logger.emit(severityNumber: Severity.INFO, body: 'should not emit');
+
+      verifyNever(() => platform.logInfo(any(), any()));
+      verifyNever(() => platform.logWarning(any(), any()));
+      verifyNever(() => platform.logError(any(), any()));
+    });
+  });
+}


### PR DESCRIPTION
Wire EmbraceLogger into getLogger() with name:version caching, mapping OTel severity numbers (1–24) to logInfo / logWarning / logError platform methods by integer range.

