### PR TITLE
feat(otel): add addSpanExporter/addLogRecordExporter to platform interface

### DIFF
--- a/embrace_platform_interface/lib/embrace_platform_interface.dart
+++ b/embrace_platform_interface/lib/embrace_platform_interface.dart
@@ -410,4 +410,26 @@ abstract class EmbracePlatform extends PlatformInterface {
   ) {
     throw UnimplementedError('addSpanLink() has not been implemented');
   }
+
+  /// Configures an OTLP HTTP span exporter on the native SDK.
+  ///
+  /// May be called before or after [attachToHostSdk].
+  void addSpanExporter({
+    required String endpoint,
+    List<Map<String, String>>? headers,
+    int? timeoutSeconds,
+  }) {
+    throw UnimplementedError('addSpanExporter() has not been implemented');
+  }
+
+  /// Configures an OTLP HTTP log record exporter on the native SDK.
+  ///
+  /// May be called before or after [attachToHostSdk].
+  void addLogRecordExporter({
+    required String endpoint,
+    List<Map<String, String>>? headers,
+    int? timeoutSeconds,
+  }) {
+    throw UnimplementedError('addLogRecordExporter() has not been implemented');
+  }
 }

--- a/embrace_platform_interface/lib/embrace_platform_interface.dart
+++ b/embrace_platform_interface/lib/embrace_platform_interface.dart
@@ -413,7 +413,7 @@ abstract class EmbracePlatform extends PlatformInterface {
 
   /// Configures an OTLP HTTP span exporter on the native SDK.
   ///
-  /// May be called before or after [attachToHostSdk].
+  /// Must be called before [attachToHostSdk].
   void addSpanExporter({
     required String endpoint,
     List<Map<String, String>>? headers,
@@ -424,7 +424,7 @@ abstract class EmbracePlatform extends PlatformInterface {
 
   /// Configures an OTLP HTTP log record exporter on the native SDK.
   ///
-  /// May be called before or after [attachToHostSdk].
+  /// Must be called before [attachToHostSdk].
   void addLogRecordExporter({
     required String endpoint,
     List<Map<String, String>>? headers,

--- a/embrace_platform_interface/lib/method_channel_embrace.dart
+++ b/embrace_platform_interface/lib/method_channel_embrace.dart
@@ -58,6 +58,8 @@ class MethodChannelEmbrace extends EmbracePlatform {
   static const String _setSpanStatusMethodName = 'setSpanStatus';
   static const String _updateSpanNameMethodName = 'updateSpanName';
   static const String _addSpanLinkMethodName = 'addSpanLink';
+  static const String _addSpanExporterMethodName = 'addSpanExporter';
+  static const String _addLogRecordExporterMethodName = 'addLogRecordExporter';
 
   // Parameter Names
   static const String _propertiesArgName = 'properties';
@@ -114,6 +116,9 @@ class MethodChannelEmbrace extends EmbracePlatform {
   static const String _descriptionArgName = 'description';
   static const String _linkedTraceIdArgName = 'linkedTraceId';
   static const String _linkedSpanIdArgName = 'linkedSpanId';
+  static const String _endpointArgName = 'endpoint';
+  static const String _headersArgName = 'headers';
+  static const String _timeoutSecondsArgName = 'timeoutSeconds';
 
   /// Minimum Embrace Android SDK version compatible with this version of
   /// the Embrace Flutter SDK
@@ -670,6 +675,32 @@ class MethodChannelEmbrace extends EmbracePlatform {
       _linkedSpanIdArgName: linkedSpanId,
       _attributesArgName: attributes,
     }) as bool;
+  }
+
+  @override
+  void addSpanExporter({
+    required String endpoint,
+    List<Map<String, String>>? headers,
+    int? timeoutSeconds,
+  }) {
+    methodChannel.invokeMethod(_addSpanExporterMethodName, {
+      _endpointArgName: endpoint,
+      _headersArgName: headers,
+      _timeoutSecondsArgName: timeoutSeconds,
+    });
+  }
+
+  @override
+  void addLogRecordExporter({
+    required String endpoint,
+    List<Map<String, String>>? headers,
+    int? timeoutSeconds,
+  }) {
+    methodChannel.invokeMethod(_addLogRecordExporterMethodName, {
+      _endpointArgName: endpoint,
+      _headersArgName: headers,
+      _timeoutSecondsArgName: timeoutSeconds,
+    });
   }
 
   /// Throws a [StateError] if the SDK has not been started.

--- a/embrace_platform_interface/lib/method_channel_embrace.dart
+++ b/embrace_platform_interface/lib/method_channel_embrace.dart
@@ -683,6 +683,7 @@ class MethodChannelEmbrace extends EmbracePlatform {
     List<Map<String, String>>? headers,
     int? timeoutSeconds,
   }) {
+    throwIfStarted();
     methodChannel.invokeMethod(_addSpanExporterMethodName, {
       _endpointArgName: endpoint,
       _headersArgName: headers,
@@ -696,6 +697,7 @@ class MethodChannelEmbrace extends EmbracePlatform {
     List<Map<String, String>>? headers,
     int? timeoutSeconds,
   }) {
+    throwIfStarted();
     methodChannel.invokeMethod(_addLogRecordExporterMethodName, {
       _endpointArgName: endpoint,
       _headersArgName: headers,
@@ -707,6 +709,13 @@ class MethodChannelEmbrace extends EmbracePlatform {
   void throwIfNotStarted() {
     if (!isStarted) {
       throw StateError('Embrace SDK has not been started.');
+    }
+  }
+
+  /// Throws a [StateError] if the SDK has already been started.
+  void throwIfStarted() {
+    if (isStarted) {
+      throw StateError('Embrace SDK has already been started.');
     }
   }
 

--- a/embrace_platform_interface/test/src/method_channel_embrace_test.dart
+++ b/embrace_platform_interface/test/src/method_channel_embrace_test.dart
@@ -1419,10 +1419,7 @@ void main() {
       ];
       const timeoutSeconds = 30;
 
-      test('invokes addSpanExporter with all arguments', () async {
-        await methodChannelEmbrace.attachToHostSdk(
-          enableIntegrationTesting: false,
-        );
+      test('invokes addSpanExporter with all arguments', () {
         methodChannelEmbrace.addSpanExporter(
           endpoint: endpoint,
           headers: headers,
@@ -1443,10 +1440,7 @@ void main() {
         );
       });
 
-      test('invokes addSpanExporter with only required argument', () async {
-        await methodChannelEmbrace.attachToHostSdk(
-          enableIntegrationTesting: false,
-        );
+      test('invokes addSpanExporter with only required argument', () {
         methodChannelEmbrace.addSpanExporter(endpoint: endpoint);
         expect(
           log,
@@ -1462,6 +1456,16 @@ void main() {
           ),
         );
       });
+
+      test('throws StateError if already started', () async {
+        await methodChannelEmbrace.attachToHostSdk(
+          enableIntegrationTesting: false,
+        );
+        expect(
+          () => methodChannelEmbrace.addSpanExporter(endpoint: endpoint),
+          throwsA(isA<StateError>()),
+        );
+      });
     });
 
     group('addLogRecordExporter', () {
@@ -1471,10 +1475,7 @@ void main() {
       ];
       const timeoutSeconds = 60;
 
-      test('invokes addLogRecordExporter with all arguments', () async {
-        await methodChannelEmbrace.attachToHostSdk(
-          enableIntegrationTesting: false,
-        );
+      test('invokes addLogRecordExporter with all arguments', () {
         methodChannelEmbrace.addLogRecordExporter(
           endpoint: endpoint,
           headers: headers,
@@ -1495,11 +1496,7 @@ void main() {
         );
       });
 
-      test('invokes addLogRecordExporter with only required argument',
-          () async {
-        await methodChannelEmbrace.attachToHostSdk(
-          enableIntegrationTesting: false,
-        );
+      test('invokes addLogRecordExporter with only required argument', () {
         methodChannelEmbrace.addLogRecordExporter(endpoint: endpoint);
         expect(
           log,
@@ -1513,6 +1510,16 @@ void main() {
               },
             ),
           ),
+        );
+      });
+
+      test('throws StateError if already started', () async {
+        await methodChannelEmbrace.attachToHostSdk(
+          enableIntegrationTesting: false,
+        );
+        expect(
+          () => methodChannelEmbrace.addLogRecordExporter(endpoint: endpoint),
+          throwsA(isA<StateError>()),
         );
       });
     });

--- a/embrace_platform_interface/test/src/method_channel_embrace_test.dart
+++ b/embrace_platform_interface/test/src/method_channel_embrace_test.dart
@@ -1411,5 +1411,110 @@ void main() {
         expect(log, isEmpty);
       });
     });
+
+    group('addSpanExporter', () {
+      const endpoint = 'https://collector.example.com/v1/traces';
+      final headers = [
+        {'Authorization': 'Bearer token123'},
+      ];
+      const timeoutSeconds = 30;
+
+      test('invokes addSpanExporter with all arguments', () async {
+        await methodChannelEmbrace.attachToHostSdk(
+          enableIntegrationTesting: false,
+        );
+        methodChannelEmbrace.addSpanExporter(
+          endpoint: endpoint,
+          headers: headers,
+          timeoutSeconds: timeoutSeconds,
+        );
+        expect(
+          log,
+          contains(
+            isMethodCall(
+              'addSpanExporter',
+              arguments: {
+                'endpoint': endpoint,
+                'headers': headers,
+                'timeoutSeconds': timeoutSeconds,
+              },
+            ),
+          ),
+        );
+      });
+
+      test('invokes addSpanExporter with only required argument', () async {
+        await methodChannelEmbrace.attachToHostSdk(
+          enableIntegrationTesting: false,
+        );
+        methodChannelEmbrace.addSpanExporter(endpoint: endpoint);
+        expect(
+          log,
+          contains(
+            isMethodCall(
+              'addSpanExporter',
+              arguments: {
+                'endpoint': endpoint,
+                'headers': null,
+                'timeoutSeconds': null,
+              },
+            ),
+          ),
+        );
+      });
+    });
+
+    group('addLogRecordExporter', () {
+      const endpoint = 'https://collector.example.com/v1/logs';
+      final headers = [
+        {'Authorization': 'Bearer token456'},
+      ];
+      const timeoutSeconds = 60;
+
+      test('invokes addLogRecordExporter with all arguments', () async {
+        await methodChannelEmbrace.attachToHostSdk(
+          enableIntegrationTesting: false,
+        );
+        methodChannelEmbrace.addLogRecordExporter(
+          endpoint: endpoint,
+          headers: headers,
+          timeoutSeconds: timeoutSeconds,
+        );
+        expect(
+          log,
+          contains(
+            isMethodCall(
+              'addLogRecordExporter',
+              arguments: {
+                'endpoint': endpoint,
+                'headers': headers,
+                'timeoutSeconds': timeoutSeconds,
+              },
+            ),
+          ),
+        );
+      });
+
+      test('invokes addLogRecordExporter with only required argument',
+          () async {
+        await methodChannelEmbrace.attachToHostSdk(
+          enableIntegrationTesting: false,
+        );
+        methodChannelEmbrace.addLogRecordExporter(endpoint: endpoint);
+        expect(
+          log,
+          contains(
+            isMethodCall(
+              'addLogRecordExporter',
+              arguments: {
+                'endpoint': endpoint,
+                'headers': null,
+                'timeoutSeconds': null,
+              },
+            ),
+          ),
+        );
+      });
+    });
   });
 }


### PR DESCRIPTION
## Summary
- Defines `addSpanExporter` and `addLogRecordExporter` abstract methods on `EmbracePlatform`
- Implements both via `MethodChannelEmbrace` using the `addSpanExporter` / `addLogRecordExporter` method channel calls
- Adds method channel tests

## Review order
This PR must merge first. [Dart implementation](#) and [native handlers](#) both depend on it and can be reviewed in parallel.

## Test plan
- [ ] Method channel tests pass (`flutter test embrace_platform_interface`)