### PR TITLE
feat(otel): implement addSpanExporter/addLogRecordExporter in Dart layer

### DIFF
--- a/embrace/lib/embrace.dart
+++ b/embrace/lib/embrace.dart
@@ -288,6 +288,42 @@ class Embrace implements EmbraceFlutterApi {
     return _platform.getDeviceId();
   }
 
+  /// Returns the [EmbraceTracerProvider] registered with the OTel API.
+  ///
+  /// Throws a [StateError] if called before [start].
+  EmbraceTracerProvider get tracerProvider {
+    if (OTelFactory.otelFactory == null) {
+      throw StateError('Embrace SDK has not been started.');
+    }
+    return OTelAPI.tracerProvider() as EmbraceTracerProvider;
+  }
+
+  /// Returns the [EmbraceLoggerProvider] registered with the OTel API.
+  ///
+  /// Throws a [StateError] if called before [start].
+  EmbraceLoggerProvider get loggerProvider {
+    if (OTelFactory.otelFactory == null) {
+      throw StateError('Embrace SDK has not been started.');
+    }
+    return OTelAPI.loggerProvider() as EmbraceLoggerProvider;
+  }
+
+  /// Resets SDK state for use in tests.
+  ///
+  /// Clears pending exporter queues on both providers (if the OTel API has
+  /// been initialised) then resets the OTel API.
+  @visibleForTesting
+  void resetForTesting() {
+    if (OTelFactory.otelFactory != null) {
+      // ignore: invalid_use_of_visible_for_testing_member
+      (OTelAPI.tracerProvider() as EmbraceTracerProvider).resetForTesting();
+      // ignore: invalid_use_of_visible_for_testing_member
+      (OTelAPI.loggerProvider() as EmbraceLoggerProvider).resetForTesting();
+    }
+    // ignore: invalid_use_of_visible_for_testing_member
+    OTelAPI.reset();
+  }
+
   @override
   void logDartError(Object error, StackTrace stack) {
     EmbracePlatform.instance.logDartError(
@@ -459,6 +495,9 @@ Future<void> _start(
       oTelFactoryCreationFunction: EmbraceOTelFactory.new,
     );
   }
+
+  (OTelAPI.tracerProvider() as EmbraceTracerProvider).flushPendingExporters();
+  (OTelAPI.loggerProvider() as EmbraceLoggerProvider).flushPendingExporters();
 
   if (action != null) {
     await _installErrorHandlers(action);

--- a/embrace/lib/src/otel/embrace_otel_factory.dart
+++ b/embrace/lib/src/otel/embrace_otel_factory.dart
@@ -1,4 +1,5 @@
 import 'package:dartastic_opentelemetry_api/dartastic_opentelemetry_api.dart';
+import 'package:embrace/src/otel/logs/embrace_logger_provider.dart';
 import 'package:embrace/src/otel/tracing/embrace_tracer_provider.dart';
 import 'package:meta/meta.dart';
 
@@ -28,6 +29,19 @@ class EmbraceOTelFactory extends OTelAPIFactory {
     String? serviceVersion = OTelAPI.defaultServiceVersion,
   }) {
     return EmbraceTracerProvider(
+      endpoint: endpoint,
+      serviceName: serviceName,
+      serviceVersion: serviceVersion,
+    );
+  }
+
+  @override
+  APILoggerProvider loggerProvider({
+    required String endpoint,
+    String serviceName = OTelAPI.defaultServiceName,
+    String? serviceVersion = OTelAPI.defaultServiceVersion,
+  }) {
+    return EmbraceLoggerProvider(
       endpoint: endpoint,
       serviceName: serviceName,
       serviceVersion: serviceVersion,

--- a/embrace/lib/src/otel/logs/embrace_logger_provider.dart
+++ b/embrace/lib/src/otel/logs/embrace_logger_provider.dart
@@ -1,23 +1,23 @@
 import 'package:dartastic_opentelemetry_api/dartastic_opentelemetry_api.dart';
-import 'package:embrace/src/otel/tracing/embrace_tracer.dart';
 import 'package:embrace_platform_interface/embrace_platform_interface.dart';
 import 'package:meta/meta.dart';
 
-typedef _SpanExporterConfig = ({
+typedef _LogExporterConfig = ({
   String endpoint,
   List<Map<String, String>>? headers,
   int? timeoutSeconds,
 });
 
-/// Embrace implementation of [APITracerProvider].
+/// Embrace implementation of [APILoggerProvider].
 ///
-/// Holds a single [EmbraceTracer] instance returned by every [getTracer] call.
-/// Registered via the Embrace OTel factory so that [OTelAPI.tracerProvider]
-/// returns this provider after Embrace.start is called.
+/// Delegates [getLogger] to the OTel API no-op implementation. The primary
+/// purpose of this class is to manage OTLP HTTP log record exporter
+/// configuration: calls may be queued before [EmbracePlatform.attachToHostSdk]
+/// and forwarded to the native SDK once [flushPendingExporters] is called.
 @internal
-class EmbraceTracerProvider implements APITracerProvider {
-  /// Creates an [EmbraceTracerProvider].
-  EmbraceTracerProvider({
+class EmbraceLoggerProvider implements APILoggerProvider {
+  /// Creates an [EmbraceLoggerProvider].
+  EmbraceLoggerProvider({
     required String endpoint,
     String serviceName = OTelAPI.defaultServiceName,
     String? serviceVersion = OTelAPI.defaultServiceVersion,
@@ -27,74 +27,72 @@ class EmbraceTracerProvider implements APITracerProvider {
         _enabled = true,
         _isShutdown = false;
 
-  late final EmbraceTracer _tracer = EmbraceTracer(provider: this);
-
-  // endpoint, serviceName, and serviceVersion satisfy the APITracerProvider
-  // interface but are not used by the Dart layer — the native Embrace SDK owns
-  // these values and manages them independently.
   String _endpoint;
   String _serviceName;
   String? _serviceVersion;
   bool _enabled;
   bool _isShutdown;
 
-  final List<_SpanExporterConfig> _pendingSpanExporters = [];
+  final List<_LogExporterConfig> _pendingLogExporters = [];
 
-  /// Returns the single [EmbraceTracer] instance regardless of [name],
-  /// [version], [schemaUrl], or [attributes]. All instrumentation shares one
-  /// tracer because span creation is delegated entirely to the native Embrace
-  /// SDK, which does not distinguish between OTel instrumentation scopes.
-  @override
-  APITracer getTracer(
-    String name, {
-    String? version,
-    String? schemaUrl,
-    Attributes? attributes,
-  }) =>
-      _tracer;
-
-  /// Adds an OTLP HTTP span exporter.
+  /// Adds an OTLP HTTP log record exporter.
   ///
   /// If the Embrace SDK has already started, the exporter is configured on the
   /// native SDK immediately. Otherwise the config is queued and forwarded once
   /// [flushPendingExporters] is called after the SDK starts.
-  void addSpanExporter({
+  void addLogRecordExporter({
     required String endpoint,
     List<Map<String, String>>? headers,
     int? timeoutSeconds,
   }) {
     if (EmbracePlatform.instance.isStarted) {
-      EmbracePlatform.instance.addSpanExporter(
+      EmbracePlatform.instance.addLogRecordExporter(
         endpoint: endpoint,
         headers: headers,
         timeoutSeconds: timeoutSeconds,
       );
     } else {
-      _pendingSpanExporters.add(
+      _pendingLogExporters.add(
         (endpoint: endpoint, headers: headers, timeoutSeconds: timeoutSeconds),
       );
     }
   }
 
-  /// Forwards all queued span exporter configs to the native SDK.
+  /// Forwards all queued log record exporter configs to the native SDK.
   ///
   /// Called by `Embrace._start` after [EmbracePlatform.attachToHostSdk].
   void flushPendingExporters() {
-    for (final config in List.of(_pendingSpanExporters)) {
-      EmbracePlatform.instance.addSpanExporter(
+    for (final config in List.of(_pendingLogExporters)) {
+      EmbracePlatform.instance.addLogRecordExporter(
         endpoint: config.endpoint,
         headers: config.headers,
         timeoutSeconds: config.timeoutSeconds,
       );
     }
-    _pendingSpanExporters.clear();
+    _pendingLogExporters.clear();
   }
 
   /// Clears the pending exporter queue. For use in tests only.
   @visibleForTesting
   void resetForTesting() {
-    _pendingSpanExporters.clear();
+    _pendingLogExporters.clear();
   }
+
+  // ── APILoggerProvider interface ──────────────────────────────────────────
+
+  @override
+  APILogger getLogger(
+    String name, {
+    String? version,
+    String? schemaUrl,
+    Attributes? attributes,
+  }) =>
+      LoggerCreate.create(
+        name: name,
+        version: version,
+        schemaUrl: schemaUrl,
+        attributes: attributes,
+      );
 
   @override
   Future<bool> shutdown() async {

--- a/embrace/lib/src/otel/otel.dart
+++ b/embrace/lib/src/otel/otel.dart
@@ -1,4 +1,5 @@
 export 'package:embrace/src/otel/embrace_otel_factory.dart';
+export 'package:embrace/src/otel/logs/embrace_logger_provider.dart';
 export 'package:embrace/src/otel/propagation/w3c_trace_context.dart';
 export 'package:embrace/src/otel/tracing/embrace_otel_span.dart';
 export 'package:embrace/src/otel/tracing/embrace_tracer.dart';

--- a/embrace/test/embrace_test.dart
+++ b/embrace/test/embrace_test.dart
@@ -5,6 +5,10 @@ import 'package:dartastic_opentelemetry_api/dartastic_opentelemetry_api.dart'
     as otel;
 import 'package:embrace/embrace.dart';
 import 'package:embrace/embrace_api.dart';
+// ignore: implementation_imports
+import 'package:embrace/src/otel/logs/embrace_logger_provider.dart';
+// ignore: implementation_imports
+import 'package:embrace/src/otel/tracing/embrace_tracer_provider.dart';
 import 'package:embrace_platform_interface/embrace_platform_interface.dart';
 import 'package:embrace_platform_interface/last_run_end_state.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -1223,6 +1227,107 @@ void main() {
         verify(
           () => embracePlatform.addSpanAttribute(id, key, value),
         ).called(1);
+      });
+    });
+
+    group('OTel provider accessors', () {
+      setUp(() {
+        when(
+          () => embracePlatform.attachToHostSdk(
+            enableIntegrationTesting: any(named: 'enableIntegrationTesting'),
+          ),
+        ).thenAnswer((_) async => true);
+        when(
+          () => embracePlatform.addSpanExporter(
+            endpoint: any(named: 'endpoint'),
+            headers: any(named: 'headers'),
+            timeoutSeconds: any(named: 'timeoutSeconds'),
+          ),
+        ).thenReturn(null);
+        when(
+          () => embracePlatform.addLogRecordExporter(
+            endpoint: any(named: 'endpoint'),
+            headers: any(named: 'headers'),
+            timeoutSeconds: any(named: 'timeoutSeconds'),
+          ),
+        ).thenReturn(null);
+      });
+
+      test(
+        'tracerProvider returns EmbraceTracerProvider after start',
+        () async {
+          await Embrace.instance.start();
+
+          expect(
+            Embrace.instance.tracerProvider,
+            isA<EmbraceTracerProvider>(),
+          );
+        },
+      );
+
+      test(
+        'loggerProvider returns EmbraceLoggerProvider after start',
+        () async {
+          await Embrace.instance.start();
+
+          expect(
+            Embrace.instance.loggerProvider,
+            isA<EmbraceLoggerProvider>(),
+          );
+        },
+      );
+
+      test('tracerProvider throws StateError before start', () {
+        expect(
+          () => Embrace.instance.tracerProvider,
+          throwsA(isA<StateError>()),
+        );
+      });
+
+      test('loggerProvider throws StateError before start', () {
+        expect(
+          () => Embrace.instance.loggerProvider,
+          throwsA(isA<StateError>()),
+        );
+      });
+
+      test('resetForTesting() clears pending exporter queues', () async {
+        // Start so providers are registered with OTelAPI
+        await Embrace.instance.start();
+
+        // Hold references before reset
+        final tracerProvider = Embrace.instance.tracerProvider;
+        final loggerProvider = Embrace.instance.loggerProvider;
+
+        // Mock isStarted false so subsequent additions are queued
+        when(() => embracePlatform.isStarted).thenReturn(false);
+        tracerProvider.addSpanExporter(endpoint: 'https://spans.example.com');
+        loggerProvider.addLogRecordExporter(
+          endpoint: 'https://logs.example.com',
+        );
+
+        // Reset clears both queues
+        // ignore: invalid_use_of_visible_for_testing_member
+        Embrace.instance.resetForTesting();
+
+        // Flush should be a no-op — queues were cleared
+        tracerProvider.flushPendingExporters();
+        loggerProvider.flushPendingExporters();
+
+        verifyNever(
+          () => embracePlatform.addSpanExporter(
+            endpoint: any(named: 'endpoint'),
+            headers: any(named: 'headers'),
+            timeoutSeconds: any(named: 'timeoutSeconds'),
+          ),
+        );
+        verifyNever(
+          () => embracePlatform.addLogRecordExporter(
+            endpoint: any(named: 'endpoint'),
+            headers: any(named: 'headers'),
+            timeoutSeconds: any(named: 'timeoutSeconds'),
+          ),
+        );
       });
     });
   });

--- a/embrace/test/src/otel/logs/embrace_logger_provider_test.dart
+++ b/embrace/test/src/otel/logs/embrace_logger_provider_test.dart
@@ -1,0 +1,212 @@
+import 'package:dartastic_opentelemetry_api/dartastic_opentelemetry_api.dart';
+// ignore: implementation_imports
+import 'package:embrace/src/otel/logs/embrace_logger_provider.dart';
+import 'package:embrace_platform_interface/embrace_platform_interface.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:plugin_platform_interface/plugin_platform_interface.dart';
+
+class MockEmbracePlatform extends Mock
+    with MockPlatformInterfaceMixin
+    implements EmbracePlatform {}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late MockEmbracePlatform platform;
+
+  setUp(() {
+    platform = MockEmbracePlatform();
+    EmbracePlatform.instance = platform;
+  });
+
+  // ignore: invalid_use_of_visible_for_testing_member
+  tearDown(OTelAPI.reset);
+
+  group('EmbraceLoggerProvider', () {
+    late EmbraceLoggerProvider provider;
+
+    setUp(() {
+      provider = EmbraceLoggerProvider(endpoint: '');
+    });
+
+    test('shutdown() sets isShutdown to true', () async {
+      expect(provider.isShutdown, isFalse);
+
+      await provider.shutdown();
+
+      expect(provider.isShutdown, isTrue);
+    });
+
+    test('shutdown() sets enabled to false', () async {
+      expect(provider.enabled, isTrue);
+
+      await provider.shutdown();
+
+      expect(provider.enabled, isFalse);
+    });
+
+    test('getLogger() returns an APILogger', () {
+      expect(provider.getLogger('test'), isA<APILogger>());
+    });
+
+    group('addLogRecordExporter', () {
+      const endpoint = 'https://collector.example.com/v1/logs';
+
+      test('forwards to platform immediately when already started', () {
+        when(() => platform.isStarted).thenReturn(true);
+        when(
+          () => platform.addLogRecordExporter(
+            endpoint: any(named: 'endpoint'),
+            headers: any(named: 'headers'),
+            timeoutSeconds: any(named: 'timeoutSeconds'),
+          ),
+        ).thenReturn(null);
+
+        provider.addLogRecordExporter(endpoint: endpoint);
+
+        verify(
+          () => platform.addLogRecordExporter(
+            endpoint: endpoint,
+            headers: any(named: 'headers'),
+            timeoutSeconds: any(named: 'timeoutSeconds'),
+          ),
+        ).called(1);
+      });
+
+      test('queues exporter when SDK not yet started', () {
+        when(() => platform.isStarted).thenReturn(false);
+        when(
+          () => platform.addLogRecordExporter(
+            endpoint: any(named: 'endpoint'),
+            headers: any(named: 'headers'),
+            timeoutSeconds: any(named: 'timeoutSeconds'),
+          ),
+        ).thenReturn(null);
+
+        provider.addLogRecordExporter(endpoint: endpoint);
+
+        verifyNever(
+          () => platform.addLogRecordExporter(
+            endpoint: any(named: 'endpoint'),
+            headers: any(named: 'headers'),
+            timeoutSeconds: any(named: 'timeoutSeconds'),
+          ),
+        );
+      });
+    });
+
+    group('flushPendingExporters', () {
+      const endpoint = 'https://collector.example.com/v1/logs';
+
+      test('forwards queued exporters to platform', () {
+        when(() => platform.isStarted).thenReturn(false);
+        when(
+          () => platform.addLogRecordExporter(
+            endpoint: any(named: 'endpoint'),
+            headers: any(named: 'headers'),
+            timeoutSeconds: any(named: 'timeoutSeconds'),
+          ),
+        ).thenReturn(null);
+
+        provider
+          ..addLogRecordExporter(
+            endpoint: endpoint,
+            headers: [
+              {'X-Api-Key': 'secret'},
+            ],
+            timeoutSeconds: 15,
+          )
+          ..flushPendingExporters();
+
+        verify(
+          () => platform.addLogRecordExporter(
+            endpoint: endpoint,
+            headers: [
+              {'X-Api-Key': 'secret'},
+            ],
+            timeoutSeconds: 15,
+          ),
+        ).called(1);
+      });
+
+      test('clears queue after flush so second flush is a no-op', () {
+        when(() => platform.isStarted).thenReturn(false);
+        when(
+          () => platform.addLogRecordExporter(
+            endpoint: any(named: 'endpoint'),
+            headers: any(named: 'headers'),
+            timeoutSeconds: any(named: 'timeoutSeconds'),
+          ),
+        ).thenReturn(null);
+
+        provider
+          ..addLogRecordExporter(endpoint: endpoint)
+          ..flushPendingExporters()
+          ..flushPendingExporters();
+
+        verify(
+          () => platform.addLogRecordExporter(
+            endpoint: any(named: 'endpoint'),
+            headers: any(named: 'headers'),
+            timeoutSeconds: any(named: 'timeoutSeconds'),
+          ),
+        ).called(1);
+      });
+    });
+
+    test('flushes multiple queued exporters in order', () {
+      when(() => platform.isStarted).thenReturn(false);
+
+      final callOrder = <String>[];
+      when(
+        () => platform.addLogRecordExporter(
+          endpoint: 'https://first.example.com',
+          headers: any(named: 'headers'),
+          timeoutSeconds: any(named: 'timeoutSeconds'),
+        ),
+      ).thenAnswer((_) => callOrder.add('first'));
+      when(
+        () => platform.addLogRecordExporter(
+          endpoint: 'https://second.example.com',
+          headers: any(named: 'headers'),
+          timeoutSeconds: any(named: 'timeoutSeconds'),
+        ),
+      ).thenAnswer((_) => callOrder.add('second'));
+
+      provider
+        ..addLogRecordExporter(endpoint: 'https://first.example.com')
+        ..addLogRecordExporter(endpoint: 'https://second.example.com')
+        ..flushPendingExporters();
+
+      expect(callOrder, ['first', 'second']);
+    });
+
+    test('resetForTesting() clears pending queue', () {
+      when(() => platform.isStarted).thenReturn(false);
+      when(
+        () => platform.addLogRecordExporter(
+          endpoint: any(named: 'endpoint'),
+          headers: any(named: 'headers'),
+          timeoutSeconds: any(named: 'timeoutSeconds'),
+        ),
+      ).thenReturn(null);
+
+      // ignore: invalid_use_of_visible_for_testing_member
+      provider
+        ..addLogRecordExporter(
+          endpoint: 'https://collector.example.com/v1/logs',
+        )
+        ..resetForTesting()
+        ..flushPendingExporters();
+
+      verifyNever(
+        () => platform.addLogRecordExporter(
+          endpoint: any(named: 'endpoint'),
+          headers: any(named: 'headers'),
+          timeoutSeconds: any(named: 'timeoutSeconds'),
+        ),
+      );
+    });
+  });
+}

--- a/embrace/test/src/otel/tracing/embrace_tracer_provider_test.dart
+++ b/embrace/test/src/otel/tracing/embrace_tracer_provider_test.dart
@@ -69,5 +69,129 @@ void main() {
 
       expect(provider.enabled, isFalse);
     });
+
+    group('addSpanExporter', () {
+      const endpoint = 'https://collector.example.com/v1/traces';
+
+      test('forwards to platform immediately when already started', () {
+        when(() => platform.isStarted).thenReturn(true);
+        when(
+          () => platform.addSpanExporter(
+            endpoint: any(named: 'endpoint'),
+            headers: any(named: 'headers'),
+            timeoutSeconds: any(named: 'timeoutSeconds'),
+          ),
+        ).thenReturn(null);
+
+        provider.addSpanExporter(endpoint: endpoint);
+
+        verify(
+          () => platform.addSpanExporter(
+            endpoint: endpoint,
+            headers: any(named: 'headers'),
+            timeoutSeconds: any(named: 'timeoutSeconds'),
+          ),
+        ).called(1);
+      });
+    });
+  });
+
+  group('EmbraceTracerProvider pre-start queueing', () {
+    test('queues exporter and flushes it when SDK starts', () async {
+      when(
+        () => platform.addSpanExporter(
+          endpoint: any(named: 'endpoint'),
+          headers: any(named: 'headers'),
+          timeoutSeconds: any(named: 'timeoutSeconds'),
+        ),
+      ).thenReturn(null);
+
+      // Call before start — platform is not yet started
+      when(() => platform.isStarted).thenReturn(false);
+      final provider = EmbraceTracerProvider(endpoint: '')
+        ..addSpanExporter(
+          endpoint: 'https://collector.example.com/v1/traces',
+          headers: [
+            {'Authorization': 'Bearer tok'},
+          ],
+          timeoutSeconds: 30,
+        );
+
+      // Platform not called yet
+      verifyNever(
+        () => platform.addSpanExporter(
+          endpoint: any(named: 'endpoint'),
+          headers: any(named: 'headers'),
+          timeoutSeconds: any(named: 'timeoutSeconds'),
+        ),
+      );
+
+      // Flush — simulates what _start() does
+      provider.flushPendingExporters();
+
+      verify(
+        () => platform.addSpanExporter(
+          endpoint: 'https://collector.example.com/v1/traces',
+          headers: [
+            {'Authorization': 'Bearer tok'},
+          ],
+          timeoutSeconds: 30,
+        ),
+      ).called(1);
+    });
+
+    test('flushes multiple queued exporters in order', () {
+      when(
+        () => platform.addSpanExporter(
+          endpoint: any(named: 'endpoint'),
+          headers: any(named: 'headers'),
+          timeoutSeconds: any(named: 'timeoutSeconds'),
+        ),
+      ).thenReturn(null);
+
+      when(() => platform.isStarted).thenReturn(false);
+      final provider = EmbraceTracerProvider(endpoint: '');
+
+      final callOrder = <String>[];
+      when(
+        () => platform.addSpanExporter(
+          endpoint: 'https://first.example.com',
+          headers: any(named: 'headers'),
+          timeoutSeconds: any(named: 'timeoutSeconds'),
+        ),
+      ).thenAnswer((_) => callOrder.add('first'));
+      when(
+        () => platform.addSpanExporter(
+          endpoint: 'https://second.example.com',
+          headers: any(named: 'headers'),
+          timeoutSeconds: any(named: 'timeoutSeconds'),
+        ),
+      ).thenAnswer((_) => callOrder.add('second'));
+
+      provider
+        ..addSpanExporter(endpoint: 'https://first.example.com')
+        ..addSpanExporter(endpoint: 'https://second.example.com')
+        ..flushPendingExporters();
+
+      expect(callOrder, ['first', 'second']);
+    });
+
+    test('resetForTesting() clears pending queue', () {
+      when(() => platform.isStarted).thenReturn(false);
+
+      // ignore: invalid_use_of_visible_for_testing_member
+      EmbraceTracerProvider(endpoint: '')
+        ..addSpanExporter(endpoint: 'https://collector.example.com')
+        ..resetForTesting()
+        ..flushPendingExporters();
+
+      verifyNever(
+        () => platform.addSpanExporter(
+          endpoint: any(named: 'endpoint'),
+          headers: any(named: 'headers'),
+          timeoutSeconds: any(named: 'timeoutSeconds'),
+        ),
+      );
+    });
   });
 }


### PR DESCRIPTION
## Summary
- Adds `addSpanExporter` / `addLogRecordExporter` to `EmbraceTracerProvider` and `EmbraceLoggerProvider`
- Calls made before `Embrace.start()` are queued and flushed after `attachToHostSdk`
- Adds tests covering multiple exporters flushed in order, provider getters, `StateError` before start, and `resetForTesting()` clearing pending queues

## Dependencies
Depends on embrace-io/embrace-flutter-sdk#219 (platform interface). Set that PR as base — merge it first.

## Test plan
- [ ] `flutter test embrace` passes