### PR TITLE
feat(otel): add native handlers for addSpanExporter/addLogRecordExporter

### DIFF
--- a/embrace_android/android/build.gradle
+++ b/embrace_android/android/build.gradle
@@ -32,5 +32,5 @@ dependencies {
   compileOnly "io.embrace:embrace-android-core:$embAndroidSdk"
   compileOnly "io.embrace:embrace-internal-api:$embAndroidSdk"
   compileOnly "io.embrace:embrace-android-otel-java:$embAndroidSdk"
-  compileOnly "io.opentelemetry:opentelemetry-exporter-otlp:1.46.0"
+  implementation "io.opentelemetry:opentelemetry-exporter-otlp:1.46.0"
 }

--- a/embrace_android/android/build.gradle
+++ b/embrace_android/android/build.gradle
@@ -31,4 +31,6 @@ dependencies {
   compileOnly "io.embrace:embrace-android-sdk:$embAndroidSdk"
   compileOnly "io.embrace:embrace-android-core:$embAndroidSdk"
   compileOnly "io.embrace:embrace-internal-api:$embAndroidSdk"
+  compileOnly "io.embrace:embrace-android-otel-java:$embAndroidSdk"
+  compileOnly "io.opentelemetry:opentelemetry-exporter-otlp:1.46.0"
 }

--- a/embrace_android/android/src/main/kotlin/io/embrace/flutter/EmbracePlugin.kt
+++ b/embrace_android/android/src/main/kotlin/io/embrace/flutter/EmbracePlugin.kt
@@ -19,6 +19,11 @@ import io.embrace.android.embracesdk.network.EmbraceNetworkRequest
 import io.embrace.android.embracesdk.spans.EmbraceSpan
 import io.embrace.android.embracesdk.spans.ErrorCode
 import io.embrace.android.embracesdk.spans.EmbraceSpanEvent
+import io.embrace.android.embracesdk.otel.java.addJavaLogRecordExporter
+import io.embrace.android.embracesdk.otel.java.addJavaSpanExporter
+import io.opentelemetry.exporter.otlp.http.logs.OtlpHttpLogRecordExporter
+import io.opentelemetry.exporter.otlp.http.trace.OtlpHttpSpanExporter
+import java.util.concurrent.TimeUnit
 
 import android.os.Handler
 import android.os.Looper
@@ -68,6 +73,8 @@ internal object EmbraceConstants {
     internal const val ADD_SPAN_ATTRIBUTE_METHOD_NAME : String = "addSpanAttribute"
     internal const val RECORD_COMPLETED_SPAN_METHOD_NAME : String = "recordCompletedSpan"
     internal const val GET_TRACE_ID_METHOD_NAME : String = "getTraceId"
+    internal const val ADD_SPAN_EXPORTER_METHOD_NAME : String = "addSpanExporter"
+    internal const val ADD_LOG_RECORD_EXPORTER_METHOD_NAME : String = "addLogRecordExporter"
 
     // Parameter Names
     internal const val ENABLE_INTEGRATION_TESTING_ARG_NAME : String = "enableIntegrationTesting"
@@ -117,6 +124,9 @@ internal object EmbraceConstants {
     internal const val TIMESTAMP_MS_ARG_NAME : String = "timestampMs"
     internal const val ATTRIBUTES_ARG_NAME : String = "attributes"
     internal const val EVENTS_ARG_NAME : String = "events"
+    internal const val ENDPOINT_ARG_NAME : String = "endpoint"
+    internal const val HEADERS_ARG_NAME : String = "headers"
+    internal const val TIMEOUT_SECONDS_ARG_NAME : String = "timeoutSeconds"
 }
 
 /**
@@ -184,6 +194,8 @@ public class EmbracePlugin : FlutterPlugin, MethodCallHandler {
                 EmbraceConstants.ADD_SPAN_ATTRIBUTE_METHOD_NAME -> handleAddSpanAttribute(call, result)
                 EmbraceConstants.RECORD_COMPLETED_SPAN_METHOD_NAME -> handleRecordCompletedSpan(call, result)
                 EmbraceConstants.GET_TRACE_ID_METHOD_NAME -> handleGetTraceId(call, result)
+                EmbraceConstants.ADD_SPAN_EXPORTER_METHOD_NAME -> handleAddSpanExporter(call, result)
+                EmbraceConstants.ADD_LOG_RECORD_EXPORTER_METHOD_NAME -> handleAddLogRecordExporter(call, result)
                 else -> {
                     result.notImplemented()
                     throw NotImplementedError("EmbracePlugin received a method call for ${call.method} but has no handler for that name.")
@@ -714,6 +726,48 @@ public class EmbracePlugin : FlutterPlugin, MethodCallHandler {
             span?.traceId
         }
         result.success(traceId)
+    }
+
+    private fun handleAddSpanExporter(call: MethodCall, result: Result) {
+        val endpoint = call.getStringArgument(EmbraceConstants.ENDPOINT_ARG_NAME)
+        if (endpoint.isEmpty()) {
+            result.success(null)
+            return
+        }
+        try {
+            val builder = OtlpHttpSpanExporter.builder().setEndpoint(endpoint)
+            val headers = call.getListArgument<Map<String, String>>(EmbraceConstants.HEADERS_ARG_NAME)
+            headers.forEach { header ->
+                header.forEach { (key, value) -> builder.addHeader(key, value) }
+            }
+            val timeoutSeconds: Int? = call.argument(EmbraceConstants.TIMEOUT_SECONDS_ARG_NAME)
+            timeoutSeconds?.let { builder.setTimeout(it.toLong(), TimeUnit.SECONDS) }
+            Embrace.addJavaSpanExporter(builder.build())
+        } catch (e: Throwable) {
+            Log.w("EmbraceFlutter", "Failed to add span exporter: ${e.message}", e)
+        }
+        result.success(null)
+    }
+
+    private fun handleAddLogRecordExporter(call: MethodCall, result: Result) {
+        val endpoint = call.getStringArgument(EmbraceConstants.ENDPOINT_ARG_NAME)
+        if (endpoint.isEmpty()) {
+            result.success(null)
+            return
+        }
+        try {
+            val builder = OtlpHttpLogRecordExporter.builder().setEndpoint(endpoint)
+            val headers = call.getListArgument<Map<String, String>>(EmbraceConstants.HEADERS_ARG_NAME)
+            headers.forEach { header ->
+                header.forEach { (key, value) -> builder.addHeader(key, value) }
+            }
+            val timeoutSeconds: Int? = call.argument(EmbraceConstants.TIMEOUT_SECONDS_ARG_NAME)
+            timeoutSeconds?.let { builder.setTimeout(it.toLong(), TimeUnit.SECONDS) }
+            Embrace.addJavaLogRecordExporter(builder.build())
+        } catch (e: Throwable) {
+            Log.w("EmbraceFlutter", "Failed to add log record exporter: ${e.message}", e)
+        }
+        result.success(null)
     }
 
     private fun mapToEvent(map: Map<String, Any>): EmbraceSpanEvent? {

--- a/embrace_ios/ios/Classes/EmbracePlugin.swift
+++ b/embrace_ios/ios/Classes/EmbracePlugin.swift
@@ -47,6 +47,8 @@ public class EmbracePlugin: NSObject, FlutterPlugin {
     static let RecordCompletedSpanMethodName = "recordCompletedSpan"
     static let GenerateW3cTraceparentMethodName = "generateW3cTraceparent"
     static let GetTraceIdMethodName = "getTraceId"
+    static let AddSpanExporterMethodName = "addSpanExporter"
+    static let AddLogRecordExporterMethodName = "addLogRecordExporter"
 
     // Parameter Names
     static let PropertiesArgName = "properties"
@@ -94,6 +96,9 @@ public class EmbracePlugin: NSObject, FlutterPlugin {
     static let AttributesArgName = "attributes"
     static let EventsArgName = "events"
     static let W3cTraceparentArgName = "traceParent"
+    static let EndpointArgName = "endpoint"
+    static let HeadersArgName = "headers"
+    static let TimeoutSecondsArgName = "timeoutSeconds"
 
     // OTel keys
     static let SpanScreenView = "emb-screen-view"
@@ -202,6 +207,10 @@ public class EmbracePlugin: NSObject, FlutterPlugin {
                 handleGenerateW3cTraceparentCall(call, result: result)
             case EmbracePlugin.GetTraceIdMethodName:
                 handleGetTraceIdCall(call, result: result)
+            case EmbracePlugin.AddSpanExporterMethodName:
+                handleAddSpanExporterCall(call, result: result)
+            case EmbracePlugin.AddLogRecordExporterMethodName:
+                handleAddLogRecordExporterCall(call, result: result)
             default:
                 result(FlutterMethodNotImplemented)
         }
@@ -676,6 +685,19 @@ public class EmbracePlugin: NSObject, FlutterPlugin {
                 result(nil)
             }
         }
+    }
+
+    private func handleAddSpanExporterCall(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
+        // OTLP HTTP span exporter configuration is not yet supported at runtime
+        // on iOS. The native EmbraceIO SDK configures exporters at startup via
+        // options; runtime addition will be supported in a future SDK release.
+        result(nil)
+    }
+
+    private func handleAddLogRecordExporterCall(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
+        // OTLP HTTP log record exporter configuration is not yet supported at
+        // runtime on iOS. See handleAddSpanExporterCall for details.
+        result(nil)
     }
 
     private func callAppleSdk<T>(action: (Embrace) -> T) -> T? {

--- a/embrace_ios/ios/Classes/EmbracePlugin.swift
+++ b/embrace_ios/ios/Classes/EmbracePlugin.swift
@@ -688,15 +688,14 @@ public class EmbracePlugin: NSObject, FlutterPlugin {
     }
 
     private func handleAddSpanExporterCall(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
-        // OTLP HTTP span exporter configuration is not yet supported at runtime
-        // on iOS. The native EmbraceIO SDK configures exporters at startup via
-        // options; runtime addition will be supported in a future SDK release.
+        // The native EmbraceIO SDK only supports configuring span exporters at
+        // startup via options; runtime addition is not supported.
         result(nil)
     }
 
     private func handleAddLogRecordExporterCall(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
-        // OTLP HTTP log record exporter configuration is not yet supported at
-        // runtime on iOS. See handleAddSpanExporterCall for details.
+        // The native EmbraceIO SDK only supports configuring log record exporters
+        // at startup via options; runtime addition is not supported.
         result(nil)
     }
 


### PR DESCRIPTION
## Summary
- **Android**: wires up `OtlpHttpSpanExporter` / `OtlpHttpLogRecordExorder` via the `embrace-android-otel-java` extension; iterates header map entries correctly; logs a warning on exporter errors instead of silently swallowing them
- **iOS**: no-op handlers (EmbraceIO 6.x does not support runtime exporter addition)

## Dependencies
Depends on embrace-io/embrace-flutter-sdk#219 (platform interface). Set that PR as base — merge it first.

## Test plan
- [ ] Android: verify OTLP spans/logs are exported with custom headers on a real device
- [ ] iOS: verify no crash on calling `addSpanExporter` / `addLogRecordExporter`