### PR TITLE
feat(otel): add addSpanExporter/addLogRecordExporter to Embrace and update example app

### DIFF
--- a/embrace/example/lib/main.dart
+++ b/embrace/example/lib/main.dart
@@ -15,12 +15,8 @@ import 'package:embrace_example/views.dart';
 import 'package:flutter/material.dart';
 
 Future<void> main() async {
-  // Start the Embrace SDK. Exporters can be configured here before
-  // installErrorHandlers() wraps runApp, so they are in place for the
-  // full app lifecycle.
-  await Embrace.instance.start();
-
-  // Send completed spans to your OTLP-compatible backend.
+  // Register OTLP exporters before starting Embrace so they are forwarded to
+  // the native SDK during initialization.
   Embrace.instance.addSpanExporter(
     endpoint: 'https://otlp.example.com/v1/traces',
     headers: [
@@ -28,8 +24,6 @@ Future<void> main() async {
     ],
     timeoutSeconds: 30,
   );
-
-  // Send log records to your OTLP-compatible backend.
   Embrace.instance.addLogRecordExporter(
     endpoint: 'https://otlp.example.com/v1/logs',
     headers: [
@@ -38,8 +32,7 @@ Future<void> main() async {
     timeoutSeconds: 30,
   );
 
-  await Embrace.instance
-      .installErrorHandlers(() => runApp(const EmbraceDemo()));
+  await Embrace.instance.start(action: () => runApp(const EmbraceDemo()));
 }
 
 class EmbraceDemo extends StatelessWidget {

--- a/embrace/example/lib/main.dart
+++ b/embrace/example/lib/main.dart
@@ -15,7 +15,28 @@ import 'package:embrace_example/views.dart';
 import 'package:flutter/material.dart';
 
 Future<void> main() async {
-  await Embrace.instance.start(action: () => runApp(const EmbraceDemo()));
+  await Embrace.instance.start();
+
+  // Send completed spans to your OTLP-compatible backend.
+  Embrace.instance.addSpanExporter(
+    endpoint: 'https://otlp.example.com/v1/traces',
+    headers: [
+      {'x-api-key': 'YOUR_API_KEY'},
+    ],
+    timeoutSeconds: 30,
+  );
+
+  // Send log records to your OTLP-compatible backend.
+  Embrace.instance.addLogRecordExporter(
+    endpoint: 'https://otlp.example.com/v1/logs',
+    headers: [
+      {'x-api-key': 'YOUR_API_KEY'},
+    ],
+    timeoutSeconds: 30,
+  );
+
+  await Embrace.instance
+      .installErrorHandlers(() => runApp(const EmbraceDemo()));
 }
 
 class EmbraceDemo extends StatelessWidget {

--- a/embrace/example/lib/main.dart
+++ b/embrace/example/lib/main.dart
@@ -15,6 +15,9 @@ import 'package:embrace_example/views.dart';
 import 'package:flutter/material.dart';
 
 Future<void> main() async {
+  // Start the Embrace SDK. Exporters can be configured here before
+  // installErrorHandlers() wraps runApp, so they are in place for the
+  // full app lifecycle.
   await Embrace.instance.start();
 
   // Send completed spans to your OTLP-compatible backend.

--- a/embrace/lib/embrace.dart
+++ b/embrace/lib/embrace.dart
@@ -289,6 +289,56 @@ class Embrace implements EmbraceFlutterApi {
     return _platform.getDeviceId();
   }
 
+  /// Adds an OTLP HTTP span exporter.
+  ///
+  /// Call this after [start] to forward completed spans to an
+  /// OTLP-compatible backend such as Grafana, Honeycomb, or your own
+  /// collector. [endpoint] must be the full OTLP/HTTP URL for traces
+  /// (e.g. `https://otlp.example.com/v1/traces`). [headers] is an optional
+  /// list of header maps (e.g. authentication tokens). [timeoutSeconds]
+  /// defaults to the native SDK's built-in timeout when omitted.
+  ///
+  /// Throws a [StateError] if called before [start].
+  void addSpanExporter({
+    required String endpoint,
+    List<Map<String, String>>? headers,
+    int? timeoutSeconds,
+  }) {
+    _runCatching(
+      'addSpanExporter',
+      () => tracerProvider.addSpanExporter(
+        endpoint: endpoint,
+        headers: headers,
+        timeoutSeconds: timeoutSeconds,
+      ),
+    );
+  }
+
+  /// Adds an OTLP HTTP log record exporter.
+  ///
+  /// Call this after [start] to forward log records to an OTLP-compatible
+  /// backend such as Grafana, Honeycomb, or your own collector. [endpoint]
+  /// must be the full OTLP/HTTP URL for logs
+  /// (e.g. `https://otlp.example.com/v1/logs`). [headers] is an optional list
+  /// of header maps (e.g. authentication tokens). [timeoutSeconds] defaults to
+  /// the native SDK's built-in timeout when omitted.
+  ///
+  /// Throws a [StateError] if called before [start].
+  void addLogRecordExporter({
+    required String endpoint,
+    List<Map<String, String>>? headers,
+    int? timeoutSeconds,
+  }) {
+    _runCatching(
+      'addLogRecordExporter',
+      () => loggerProvider.addLogRecordExporter(
+        endpoint: endpoint,
+        headers: headers,
+        timeoutSeconds: timeoutSeconds,
+      ),
+    );
+  }
+
   /// Returns the [EmbraceTracerProvider] registered with the OTel API.
   ///
   /// Throws a [StateError] if called before [start].

--- a/embrace/lib/embrace.dart
+++ b/embrace/lib/embrace.dart
@@ -295,10 +295,12 @@ class Embrace implements EmbraceFlutterApi {
   /// OTLP-compatible backend such as Grafana, Honeycomb, or your own
   /// collector. [endpoint] must be the full OTLP/HTTP URL for traces
   /// (e.g. `https://otlp.example.com/v1/traces`). [headers] is an optional
-  /// list of header maps (e.g. authentication tokens). [timeoutSeconds]
-  /// defaults to the native SDK's built-in timeout when omitted.
+  /// list of single-entry maps, one per header, e.g.
+  /// `[{'x-api-key': 'token'}]` — this mirrors the format expected by the
+  /// platform method channel. [timeoutSeconds] defaults to the platform SDK's
+  /// default timeout when omitted.
   ///
-  /// Throws a [StateError] if called before [start].
+  /// Has no effect if called before [start].
   void addSpanExporter({
     required String endpoint,
     List<Map<String, String>>? headers,
@@ -320,10 +322,12 @@ class Embrace implements EmbraceFlutterApi {
   /// backend such as Grafana, Honeycomb, or your own collector. [endpoint]
   /// must be the full OTLP/HTTP URL for logs
   /// (e.g. `https://otlp.example.com/v1/logs`). [headers] is an optional list
-  /// of header maps (e.g. authentication tokens). [timeoutSeconds] defaults to
-  /// the native SDK's built-in timeout when omitted.
+  /// of single-entry maps, one per header, e.g. `[{'x-api-key': 'token'}]` —
+  /// this mirrors the format expected by the platform method channel.
+  /// [timeoutSeconds] defaults to the platform SDK's default timeout when
+  /// omitted.
   ///
-  /// Throws a [StateError] if called before [start].
+  /// Has no effect if called before [start].
   void addLogRecordExporter({
     required String endpoint,
     List<Map<String, String>>? headers,

--- a/embrace/lib/embrace.dart
+++ b/embrace/lib/embrace.dart
@@ -291,21 +291,19 @@ class Embrace implements EmbraceFlutterApi {
 
   /// Adds an OTLP HTTP span exporter.
   ///
-  /// Call this after [start] to forward completed spans to an
-  /// OTLP-compatible backend such as Grafana, Honeycomb, or your own
-  /// collector. [endpoint] must be the full OTLP/HTTP URL for traces
-  /// (e.g. `https://otlp.example.com/v1/traces`). [headers] is an optional
-  /// list of single-entry maps, one per header, e.g.
+  /// Must be called before [start] so the exporter is registered before the
+  /// native SDK initializes. [endpoint] must be the full OTLP/HTTP URL for
+  /// traces (e.g. `https://otlp.example.com/v1/traces`). [headers] is an
+  /// optional list of single-entry maps, one per header, e.g.
   /// `[{'x-api-key': 'token'}]` — this mirrors the format expected by the
   /// platform method channel. [timeoutSeconds] defaults to the platform SDK's
   /// default timeout when omitted.
-  ///
-  /// Has no effect if called before [start].
   void addSpanExporter({
     required String endpoint,
     List<Map<String, String>>? headers,
     int? timeoutSeconds,
   }) {
+    _ensureOTelInitialized();
     _runCatching(
       'addSpanExporter',
       () => tracerProvider.addSpanExporter(
@@ -318,21 +316,19 @@ class Embrace implements EmbraceFlutterApi {
 
   /// Adds an OTLP HTTP log record exporter.
   ///
-  /// Call this after [start] to forward log records to an OTLP-compatible
-  /// backend such as Grafana, Honeycomb, or your own collector. [endpoint]
-  /// must be the full OTLP/HTTP URL for logs
-  /// (e.g. `https://otlp.example.com/v1/logs`). [headers] is an optional list
-  /// of single-entry maps, one per header, e.g. `[{'x-api-key': 'token'}]` —
-  /// this mirrors the format expected by the platform method channel.
+  /// Must be called before [start] so the exporter is registered before the
+  /// native SDK initializes. [endpoint] must be the full OTLP/HTTP URL for
+  /// logs (e.g. `https://otlp.example.com/v1/logs`). [headers] is an optional
+  /// list of single-entry maps, one per header, e.g. `[{'x-api-key': 'token'}]`
+  /// — this mirrors the format expected by the platform method channel.
   /// [timeoutSeconds] defaults to the platform SDK's default timeout when
   /// omitted.
-  ///
-  /// Has no effect if called before [start].
   void addLogRecordExporter({
     required String endpoint,
     List<Map<String, String>>? headers,
     int? timeoutSeconds,
   }) {
+    _ensureOTelInitialized();
     _runCatching(
       'addLogRecordExporter',
       () => loggerProvider.addLogRecordExporter(
@@ -341,6 +337,12 @@ class Embrace implements EmbraceFlutterApi {
         timeoutSeconds: timeoutSeconds,
       ),
     );
+  }
+
+  void _ensureOTelInitialized() {
+    if (OTelFactory.otelFactory == null) {
+      OTelAPI.initialize(oTelFactoryCreationFunction: EmbraceOTelFactory.new);
+    }
   }
 
   /// Returns the [EmbraceTracerProvider] registered with the OTel API.
@@ -541,18 +543,21 @@ Future<void> _start(
 ) async {
   WidgetsFlutterBinding.ensureInitialized();
 
-  await EmbracePlatform.instance.attachToHostSdk(
-    enableIntegrationTesting: enableIntegrationTesting,
-  );
-
   if (OTelFactory.otelFactory == null) {
     OTelAPI.initialize(
       oTelFactoryCreationFunction: EmbraceOTelFactory.new,
     );
   }
 
+  // Forward any pre-start exporter configs to the native SDK before it
+  // initializes. The native SDK requires exporters to be registered before
+  // attachToHostSdk is called.
   (OTelAPI.tracerProvider() as EmbraceTracerProvider).flushPendingExporters();
   (OTelAPI.loggerProvider() as EmbraceLoggerProvider).flushPendingExporters();
+
+  await EmbracePlatform.instance.attachToHostSdk(
+    enableIntegrationTesting: enableIntegrationTesting,
+  );
 
   if (action != null) {
     await _installErrorHandlers(action);

--- a/embrace/lib/embrace.dart
+++ b/embrace/lib/embrace.dart
@@ -12,6 +12,7 @@ import 'package:flutter/widgets.dart';
 export 'package:embrace_platform_interface/http_method.dart' show HttpMethod;
 export 'src/http_client.dart';
 export 'src/navigation_observer.dart';
+export 'src/otel/propagation/w3c_trace_context.dart';
 
 @visibleForTesting
 

--- a/embrace/lib/src/http_client.dart
+++ b/embrace/lib/src/http_client.dart
@@ -1,6 +1,5 @@
 import 'package:embrace/embrace.dart';
 import 'package:embrace/embrace_api.dart';
-import 'package:embrace/src/otel/propagation/w3c_trace_context.dart';
 import 'package:embrace_platform_interface/http_method.dart';
 import 'package:http/http.dart';
 

--- a/embrace/test/embrace_test.dart
+++ b/embrace/test/embrace_test.dart
@@ -1384,7 +1384,8 @@ void main() {
       );
 
       test(
-        'addLogRecordExporter before start queues config without calling platform',
+        'addLogRecordExporter before start queues config without '
+        'calling platform',
         () {
           Embrace.instance.addLogRecordExporter(
             endpoint: 'https://otlp.example.com/v1/logs',

--- a/embrace/test/embrace_test.dart
+++ b/embrace/test/embrace_test.dart
@@ -1291,6 +1291,83 @@ void main() {
         );
       });
 
+      test('addSpanExporter delegates to platform after start', () async {
+        await Embrace.instance.start();
+        when(() => embracePlatform.isStarted).thenReturn(true);
+
+        Embrace.instance.addSpanExporter(
+          endpoint: 'https://otlp.example.com/v1/traces',
+          headers: [
+            {'x-api-key': 'key'},
+          ],
+          timeoutSeconds: 30,
+        );
+
+        verify(
+          () => embracePlatform.addSpanExporter(
+            endpoint: 'https://otlp.example.com/v1/traces',
+            headers: [
+              {'x-api-key': 'key'},
+            ],
+            timeoutSeconds: 30,
+          ),
+        ).called(1);
+      });
+
+      test('addSpanExporter has no effect before start', () {
+        Embrace.instance.addSpanExporter(
+          endpoint: 'https://otlp.example.com/v1/traces',
+        );
+
+        verifyNever(
+          () => embracePlatform.addSpanExporter(
+            endpoint: any(named: 'endpoint'),
+            headers: any(named: 'headers'),
+            timeoutSeconds: any(named: 'timeoutSeconds'),
+          ),
+        );
+      });
+
+      test(
+        'addLogRecordExporter delegates to platform after start',
+        () async {
+          await Embrace.instance.start();
+          when(() => embracePlatform.isStarted).thenReturn(true);
+
+          Embrace.instance.addLogRecordExporter(
+            endpoint: 'https://otlp.example.com/v1/logs',
+            headers: [
+              {'x-api-key': 'key'},
+            ],
+            timeoutSeconds: 30,
+          );
+
+          verify(
+            () => embracePlatform.addLogRecordExporter(
+              endpoint: 'https://otlp.example.com/v1/logs',
+              headers: [
+                {'x-api-key': 'key'},
+              ],
+              timeoutSeconds: 30,
+            ),
+          ).called(1);
+        },
+      );
+
+      test('addLogRecordExporter has no effect before start', () {
+        Embrace.instance.addLogRecordExporter(
+          endpoint: 'https://otlp.example.com/v1/logs',
+        );
+
+        verifyNever(
+          () => embracePlatform.addLogRecordExporter(
+            endpoint: any(named: 'endpoint'),
+            headers: any(named: 'headers'),
+            timeoutSeconds: any(named: 'timeoutSeconds'),
+          ),
+        );
+      });
+
       test('resetForTesting() clears pending exporter queues', () async {
         // Start so providers are registered with OTelAPI
         await Embrace.instance.start();

--- a/embrace/test/embrace_test.dart
+++ b/embrace/test/embrace_test.dart
@@ -1251,6 +1251,7 @@ void main() {
             timeoutSeconds: any(named: 'timeoutSeconds'),
           ),
         ).thenReturn(null);
+        when(() => embracePlatform.isStarted).thenReturn(false);
       });
 
       test(
@@ -1314,19 +1315,47 @@ void main() {
         ).called(1);
       });
 
-      test('addSpanExporter has no effect before start', () {
-        Embrace.instance.addSpanExporter(
-          endpoint: 'https://otlp.example.com/v1/traces',
-        );
+      test(
+        'addSpanExporter before start queues config without calling platform',
+        () {
+          Embrace.instance.addSpanExporter(
+            endpoint: 'https://otlp.example.com/v1/traces',
+          );
 
-        verifyNever(
-          () => embracePlatform.addSpanExporter(
-            endpoint: any(named: 'endpoint'),
-            headers: any(named: 'headers'),
-            timeoutSeconds: any(named: 'timeoutSeconds'),
-          ),
-        );
-      });
+          verifyNever(
+            () => embracePlatform.addSpanExporter(
+              endpoint: any(named: 'endpoint'),
+              headers: any(named: 'headers'),
+              timeoutSeconds: any(named: 'timeoutSeconds'),
+            ),
+          );
+        },
+      );
+
+      test(
+        'addSpanExporter before start is sent to platform during start',
+        () async {
+          Embrace.instance.addSpanExporter(
+            endpoint: 'https://otlp.example.com/v1/traces',
+            headers: [
+              {'x-api-key': 'key'},
+            ],
+            timeoutSeconds: 30,
+          );
+
+          await Embrace.instance.start();
+
+          verify(
+            () => embracePlatform.addSpanExporter(
+              endpoint: 'https://otlp.example.com/v1/traces',
+              headers: [
+                {'x-api-key': 'key'},
+              ],
+              timeoutSeconds: 30,
+            ),
+          ).called(1);
+        },
+      );
 
       test(
         'addLogRecordExporter delegates to platform after start',
@@ -1354,19 +1383,47 @@ void main() {
         },
       );
 
-      test('addLogRecordExporter has no effect before start', () {
-        Embrace.instance.addLogRecordExporter(
-          endpoint: 'https://otlp.example.com/v1/logs',
-        );
+      test(
+        'addLogRecordExporter before start queues config without calling platform',
+        () {
+          Embrace.instance.addLogRecordExporter(
+            endpoint: 'https://otlp.example.com/v1/logs',
+          );
 
-        verifyNever(
-          () => embracePlatform.addLogRecordExporter(
-            endpoint: any(named: 'endpoint'),
-            headers: any(named: 'headers'),
-            timeoutSeconds: any(named: 'timeoutSeconds'),
-          ),
-        );
-      });
+          verifyNever(
+            () => embracePlatform.addLogRecordExporter(
+              endpoint: any(named: 'endpoint'),
+              headers: any(named: 'headers'),
+              timeoutSeconds: any(named: 'timeoutSeconds'),
+            ),
+          );
+        },
+      );
+
+      test(
+        'addLogRecordExporter before start is sent to platform during start',
+        () async {
+          Embrace.instance.addLogRecordExporter(
+            endpoint: 'https://otlp.example.com/v1/logs',
+            headers: [
+              {'x-api-key': 'key'},
+            ],
+            timeoutSeconds: 30,
+          );
+
+          await Embrace.instance.start();
+
+          verify(
+            () => embracePlatform.addLogRecordExporter(
+              endpoint: 'https://otlp.example.com/v1/logs',
+              headers: [
+                {'x-api-key': 'key'},
+              ],
+              timeoutSeconds: 30,
+            ),
+          ).called(1);
+        },
+      );
 
       test('resetForTesting() clears pending exporter queues', () async {
         // Start so providers are registered with OTelAPI

--- a/embrace/test/src/otel/propagation/w3c_trace_context_test.dart
+++ b/embrace/test/src/otel/propagation/w3c_trace_context_test.dart
@@ -1,8 +1,6 @@
 import 'package:dartastic_opentelemetry_api/dartastic_opentelemetry_api.dart';
 import 'package:embrace/embrace.dart';
 // ignore: implementation_imports
-import 'package:embrace/src/otel/propagation/w3c_trace_context.dart';
-// ignore: implementation_imports
 import 'package:embrace/src/otel/tracing/embrace_tracer.dart';
 // ignore: implementation_imports
 import 'package:embrace/src/otel/tracing/embrace_tracer_provider.dart';


### PR DESCRIPTION
Expose addSpanExporter and addLogRecordExporter as public convenience
methods on the Embrace class so callers don't need to reference the
[@internal](https://github.com/internal) provider types directly. Update the example app to demonstrate
configuring OTLP exporters after Embrace.start().