### PR TITLE
Release 4.5.0

### DIFF
--- a/embrace/CHANGELOG.md
+++ b/embrace/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 4.5.0
+
+* Updated Embrace iOS SDK to 6.17.1
+* Fixed embrace_dio not recording HTTP error responses with status code
+
 # 4.4.0
 
 * Updated Embrace Android SDK to 8.2.0

--- a/embrace/pubspec.yaml
+++ b/embrace/pubspec.yaml
@@ -1,6 +1,6 @@
 name: embrace
 description: A comprehensive observability and monitoring platform for iOS and Android apps built with Flutter.
-version: 4.4.0
+version: 4.5.0
 homepage: https://embrace.io
 environment:
   sdk: ">=3.0.0 <4.0.0"
@@ -13,9 +13,9 @@ flutter:
       ios:
         default_package: embrace_ios
 dependencies:
-  embrace_android: ">=4.4.0 <4.5.0"
-  embrace_ios: ">=4.4.0 <4.5.0"
-  embrace_platform_interface: ">=4.4.0 <4.5.0"
+  embrace_android: ">=4.5.0 <4.6.0"
+  embrace_ios: ">=4.5.0 <4.6.0"
+  embrace_platform_interface: ">=4.5.0 <4.6.0"
   flutter:
     sdk: flutter
   http: ">=0.13.3 <2.0.0"

--- a/embrace_android/CHANGELOG.md
+++ b/embrace_android/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 4.5.0
+
+* Version bump
+
 # 4.4.0
 
 * Updated Embrace Android SDK to 8.2.0

--- a/embrace_android/pubspec.yaml
+++ b/embrace_android/pubspec.yaml
@@ -1,6 +1,6 @@
 name: embrace_android
 description: Android implementation of the embrace plugin as defined by the embrace_platform_interface package.
-version: 4.4.0
+version: 4.5.0
 homepage: https://embrace.io
 environment:
   sdk: ">=3.0.0 <4.0.0"
@@ -14,7 +14,7 @@ flutter:
         pluginClass: EmbracePlugin
         dartPluginClass: EmbraceAndroid
 dependencies:
-  embrace_platform_interface: ">=4.4.0 <4.5.0"
+  embrace_platform_interface: ">=4.5.0 <4.6.0"
   flutter:
     sdk: flutter
 dev_dependencies:

--- a/embrace_dio/CHANGELOG.md
+++ b/embrace_dio/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 4.5.0
+
+* Fixed not recording HTTP error responses with status code
+
 # 4.4.0
 
 * Updated Embrace Android SDK to 8.2.0

--- a/embrace_dio/pubspec.yaml
+++ b/embrace_dio/pubspec.yaml
@@ -1,6 +1,6 @@
 name: embrace_dio
 description: Allows automatic Dio network capture when using the the embrace plugin.
-version: 4.4.0
+version: 4.5.0
 homepage: https://embrace.io
 environment:
   sdk: ">=3.0.0 <4.0.0"
@@ -9,12 +9,12 @@ dependencies:
   build_runner: ^2.0.0
   build_version: ^2.0.0
   dio: '>=4.0.0 <6.0.0'
-  embrace: ^4.4.0
+  embrace: ^4.5.0
   flutter:
     sdk: flutter
   platform: ^3.1.0
   plugin_platform_interface: ^2.1.0
-  embrace_platform_interface: ">=4.4.0 <4.5.0"
+  embrace_platform_interface: ">=4.5.0 <4.6.0"
 dev_dependencies:
   flutter_test:
     sdk: flutter

--- a/embrace_ios/CHANGELOG.md
+++ b/embrace_ios/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 4.5.0
+
+* Updated Embrace iOS SDK to 6.17.1
+
 # 4.4.0
 
 * Updated Embrace iOS SDK to 6.16.3

--- a/embrace_ios/pubspec.yaml
+++ b/embrace_ios/pubspec.yaml
@@ -1,6 +1,6 @@
 name: embrace_ios
 description: iOS implementation of the embrace plugin as defined by the embrace_platform_interface package.
-version: 4.4.0
+version: 4.5.0
 homepage: https://embrace.io
 environment:
   sdk: ">=3.0.0 <4.0.0"
@@ -13,7 +13,7 @@ flutter:
         pluginClass: EmbracePlugin
         dartPluginClass: EmbraceIOS
 dependencies:
-  embrace_platform_interface: ">=4.4.0 <4.5.0"
+  embrace_platform_interface: ">=4.5.0 <4.6.0"
   flutter:
     sdk: flutter
 dev_dependencies:

--- a/embrace_platform_interface/CHANGELOG.md
+++ b/embrace_platform_interface/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 4.5.0
+
+* Version bump
+
 # 4.4.0
 
 * Updated Embrace Android SDK to 8.2.0

--- a/embrace_platform_interface/lib/src/version.dart
+++ b/embrace_platform_interface/lib/src/version.dart
@@ -1,2 +1,2 @@
 // Generated code. Do not modify.
-const packageVersion = '4.4.0';
+const packageVersion = '4.5.0';

--- a/embrace_platform_interface/pubspec.yaml
+++ b/embrace_platform_interface/pubspec.yaml
@@ -1,6 +1,6 @@
 name: embrace_platform_interface
 description: A common platform interface for the Embrace plugin that enables platform-specific implementations.
-version: 4.4.0
+version: 4.5.0
 homepage: https://embrace.io
 environment:
   sdk: ">=3.0.0 <4.0.0"


### PR DESCRIPTION
## Summary

* Bump all packages to 4.5.0
* Updated Embrace iOS SDK to 6.17.1
* Fixed embrace_dio not recording HTTP error responses with status code