### PR TITLE
fix(iOS): logPushNotification silently drops call when optional params are nil

### DIFF
--- a/embrace_ios/ios/Classes/EmbracePlugin.swift
+++ b/embrace_ios/ios/Classes/EmbracePlugin.swift
@@ -241,10 +241,10 @@ public class EmbracePlugin: NSObject, FlutterPlugin {
         callAppleSdk { client in
             if let args = call.arguments as? [String: Any],
                 let title = args[EmbracePlugin.TitleArgName] as? String,
-                let body = args[EmbracePlugin.BodyArgName] as? String,
-                let subtitle = args[EmbracePlugin.SubtitleArgName] as? String,
-                let badge = args[EmbracePlugin.BadgeArgName] as? Int,
-                let category = args[EmbracePlugin.CategoryArgName] as? String {
+                let body = args[EmbracePlugin.BodyArgName] as? String {
+                let subtitle = args[EmbracePlugin.SubtitleArgName] as? String ?? ""
+                let badge = args[EmbracePlugin.BadgeArgName] as? Int ?? 0
+                let category = args[EmbracePlugin.CategoryArgName] as? String ?? ""
 
                 let pushData: [AnyHashable: Any?] = [
                     "aps": [

--- a/embrace_ios/ios/Classes/EmbracePlugin.swift
+++ b/embrace_ios/ios/Classes/EmbracePlugin.swift
@@ -242,9 +242,9 @@ public class EmbracePlugin: NSObject, FlutterPlugin {
             if let args = call.arguments as? [String: Any],
                 let title = args[EmbracePlugin.TitleArgName] as? String,
                 let body = args[EmbracePlugin.BodyArgName] as? String {
-                let subtitle = args[EmbracePlugin.SubtitleArgName] as? String ?? ""
-                let badge = args[EmbracePlugin.BadgeArgName] as? Int ?? 0
-                let category = args[EmbracePlugin.CategoryArgName] as? String ?? ""
+                let subtitle = args[EmbracePlugin.SubtitleArgName] as? String
+                let badge = args[EmbracePlugin.BadgeArgName] as? Int
+                let category = args[EmbracePlugin.CategoryArgName] as? String
 
                 let pushData: [AnyHashable: Any?] = [
                     "aps": [


### PR DESCRIPTION
Setup badget, subtitle and category to be nil when not providing. This fixes an issue where the log isn't seen at all when all the parameters aren't provided.