### PR TITLE
4.6.0 fixes

### DIFF
--- a/embrace/example/android/app/build.gradle
+++ b/embrace/example/android/app/build.gradle
@@ -54,4 +54,5 @@ flutter {
 
 dependencies {
     implementation "androidx.multidex:multidex:2.0.1"
+    implementation "io.embrace:embrace-android-otel-java:8.2.0"
 }

--- a/embrace/example/lib/network.dart
+++ b/embrace/example/lib/network.dart
@@ -1,3 +1,4 @@
+import 'package:dartastic_opentelemetry_api/dartastic_opentelemetry_api.dart';
 import 'package:embrace/embrace.dart';
 import 'package:flutter/material.dart';
 import 'package:http/http.dart' as http;
@@ -12,11 +13,12 @@ class NetworkDemo extends StatefulWidget {
 class _NetworkDemoState extends State<NetworkDemo> {
   final TextEditingController _controller = TextEditingController();
   late final http.Client _client = EmbraceHttpClient();
+  String _responseBody = '';
 
   @override
   void initState() {
     super.initState();
-    _controller.text = 'https://httpbin.org/get';
+    _controller.text = 'https://httpbin.org/headers';
   }
 
   @override
@@ -50,6 +52,25 @@ class _NetworkDemoState extends State<NetworkDemo> {
               onPressed: () => sendAndLogRequest(HttpMethod.delete),
               child: const Text('Delete'),
             ),
+            const Divider(),
+            ElevatedButton(
+              onPressed: _sendWithActiveSpan,
+              child: const Text('Get (with active OTel span)'),
+            ),
+            const SizedBox(height: 16),
+            const Text(
+              'Response (check for Traceparent header):',
+              style: TextStyle(fontWeight: FontWeight.bold),
+            ),
+            const SizedBox(height: 8),
+            Expanded(
+              child: SingleChildScrollView(
+                child: Text(
+                  _responseBody,
+                  style: const TextStyle(fontFamily: 'monospace', fontSize: 12),
+                ),
+              ),
+            ),
           ],
         ),
       ),
@@ -63,28 +84,43 @@ class _NetworkDemoState extends State<NetworkDemo> {
     super.dispose();
   }
 
+  Future<void> _sendWithActiveSpan() async {
+    final tracer = OTelAPI.tracerProvider().getTracer('network-demo');
+    final span = tracer.startSpan('network-request-span');
+    try {
+      await sendAndLogRequest(HttpMethod.get);
+    } finally {
+      span.end();
+    }
+  }
+
   Future<void> sendAndLogRequest(HttpMethod method) async {
     final url = Uri.parse(_controller.text);
+    http.Response? response;
 
     switch (method) {
       case HttpMethod.put:
-        await _client.put(url);
+        response = await _client.put(url);
         break;
       case HttpMethod.post:
-        await _client.post(url);
+        response = await _client.post(url);
         break;
       case HttpMethod.patch:
-        await _client.patch(url);
+        response = await _client.patch(url);
         break;
       case HttpMethod.delete:
-        await _client.delete(url);
+        response = await _client.delete(url);
         break;
       case HttpMethod.get:
-        await _client.get(url);
+        response = await _client.get(url);
         break;
       case HttpMethod.other:
-        await _client.get(url);
+        response = await _client.get(url);
         break;
     }
+
+    setState(() {
+      _responseBody = response?.body ?? '';
+    });
   }
 }

--- a/embrace_android/android/src/main/kotlin/io/embrace/flutter/EmbracePlugin.kt
+++ b/embrace_android/android/src/main/kotlin/io/embrace/flutter/EmbracePlugin.kt
@@ -665,7 +665,7 @@ public class EmbracePlugin : FlutterPlugin, MethodCallHandler {
                 startSpan(name, null, startTimeMs)
             }
          }
-        result.success(span)
+        result.success(span?.spanId)
     }
 
     private fun handleStopSpan(call: MethodCall, result: Result) {


### PR DESCRIPTION
Fixed issues                                                                                                                                                                                                   
  1. embrace-android-otel-java missing from the example app's runtime classpath — added implementation "io.embrace:embrace-android-otel-java:8.2.0" to app/build.gradle
  2. handleStartSpan in EmbracePlugin.kt returning a raw EmbraceSpanImpl object over the method channel instead of span?.spanId
 
Also added a way to confirm W3C transparent in the example app. 