### PR TITLE
Release 4.6.0

### DIFF
--- a/embrace/CHANGELOG.md
+++ b/embrace/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 4.6.0
+
+* Added OpenTelemetry API compliance: `EmbraceOTelFactory`, `EmbraceTracerProvider`, `EmbraceTracer`, `EmbraceLoggerProvider`, and `EmbraceLogger` are now registered with `dartastic_opentelemetry_api` on `Embrace.start()`
+* Added `addSpanExporter` and `addLogRecordExporter` to configure OTLP export destinations from Dart
+* Added W3C traceparent header injection in `EmbraceHttpClient`
+
 # 4.5.0
 
 * Updated Embrace iOS SDK to 6.17.1

--- a/embrace/pubspec.yaml
+++ b/embrace/pubspec.yaml
@@ -20,6 +20,7 @@ dependencies:
   flutter:
     sdk: flutter
   http: ">=0.13.3 <2.0.0"
+  meta: ^1.9.0
 dev_dependencies:
   flutter_test:
     sdk: flutter

--- a/embrace/pubspec.yaml
+++ b/embrace/pubspec.yaml
@@ -1,6 +1,6 @@
 name: embrace
 description: A comprehensive observability and monitoring platform for iOS and Android apps built with Flutter.
-version: 4.5.0
+version: 4.6.0
 homepage: https://embrace.io
 environment:
   sdk: ">=3.0.0 <4.0.0"
@@ -14,9 +14,9 @@ flutter:
         default_package: embrace_ios
 dependencies:
   dartastic_opentelemetry_api: ^1.0.0-alpha
-  embrace_android: ">=4.5.0 <4.6.0"
-  embrace_ios: ">=4.5.0 <4.6.0"
-  embrace_platform_interface: ">=4.5.0 <4.6.0"
+  embrace_android: ">=4.6.0 <4.7.0"
+  embrace_ios: ">=4.6.0 <4.7.0"
+  embrace_platform_interface: ">=4.6.0 <4.7.0"
   flutter:
     sdk: flutter
   http: ">=0.13.3 <2.0.0"

--- a/embrace_android/CHANGELOG.md
+++ b/embrace_android/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 4.6.0
+
+* Added native handlers for `setSpanStatus`, `updateSpanName`, and `addSpanLink`
+* Added native handlers for `addSpanExporter` and `addLogRecordExporter`
+
 # 4.5.0
 
 * Version bump

--- a/embrace_android/pubspec.yaml
+++ b/embrace_android/pubspec.yaml
@@ -1,6 +1,6 @@
 name: embrace_android
 description: Android implementation of the embrace plugin as defined by the embrace_platform_interface package.
-version: 4.5.0
+version: 4.6.0
 homepage: https://embrace.io
 environment:
   sdk: ">=3.0.0 <4.0.0"
@@ -14,7 +14,7 @@ flutter:
         pluginClass: EmbracePlugin
         dartPluginClass: EmbraceAndroid
 dependencies:
-  embrace_platform_interface: ">=4.5.0 <4.6.0"
+  embrace_platform_interface: ">=4.6.0 <4.7.0"
   flutter:
     sdk: flutter
 dev_dependencies:

--- a/embrace_dio/CHANGELOG.md
+++ b/embrace_dio/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 4.6.0
+
+* Added W3C traceparent header injection in `EmbraceInterceptor`
+
 # 4.5.0
 
 * Fixed not recording HTTP error responses with status code

--- a/embrace_dio/pubspec.yaml
+++ b/embrace_dio/pubspec.yaml
@@ -1,6 +1,6 @@
 name: embrace_dio
 description: Allows automatic Dio network capture when using the the embrace plugin.
-version: 4.5.0
+version: 4.6.0
 homepage: https://embrace.io
 environment:
   sdk: ">=3.0.0 <4.0.0"
@@ -9,12 +9,12 @@ dependencies:
   build_runner: ^2.0.0
   build_version: ^2.0.0
   dio: '>=4.0.0 <6.0.0'
-  embrace: ^4.5.0
+  embrace: ^4.6.0
   flutter:
     sdk: flutter
   platform: ^3.1.0
   plugin_platform_interface: ^2.1.0
-  embrace_platform_interface: ">=4.5.0 <4.6.0"
+  embrace_platform_interface: ">=4.6.0 <4.7.0"
 dev_dependencies:
   dartastic_opentelemetry_api: ^1.0.0-alpha
   flutter_test:

--- a/embrace_ios/CHANGELOG.md
+++ b/embrace_ios/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 4.6.0
+
+* Added native handlers for `setSpanStatus`, `updateSpanName`, and `addSpanLink`
+* Added native handlers for `addSpanExporter` and `addLogRecordExporter`
+* Fixed `logPushNotification` silently dropping calls when optional parameters are nil
+
 # 4.5.0
 
 * Updated Embrace iOS SDK to 6.17.1

--- a/embrace_ios/pubspec.yaml
+++ b/embrace_ios/pubspec.yaml
@@ -1,6 +1,6 @@
 name: embrace_ios
 description: iOS implementation of the embrace plugin as defined by the embrace_platform_interface package.
-version: 4.5.0
+version: 4.6.0
 homepage: https://embrace.io
 environment:
   sdk: ">=3.0.0 <4.0.0"
@@ -13,7 +13,7 @@ flutter:
         pluginClass: EmbracePlugin
         dartPluginClass: EmbraceIOS
 dependencies:
-  embrace_platform_interface: ">=4.5.0 <4.6.0"
+  embrace_platform_interface: ">=4.6.0 <4.7.0"
   flutter:
     sdk: flutter
 dev_dependencies:

--- a/embrace_platform_interface/CHANGELOG.md
+++ b/embrace_platform_interface/CHANGELOG.md
@@ -1,3 +1,11 @@
+# 4.6.0
+
+* Added `EmbraceOTelSpan` (implements `APISpan`) with span lifecycle methods
+* Added new platform methods: `setSpanStatus`, `updateSpanName`, `addSpanLink`
+* Added `addSpanExporter` and `addLogRecordExporter` to `EmbracePlatform`
+* Added `W3cTraceContext` for W3C traceparent parsing and injection
+* Added `OTelContextUtils` for OpenTelemetry context management
+
 # 4.5.0
 
 * Version bump

--- a/embrace_platform_interface/lib/src/version.dart
+++ b/embrace_platform_interface/lib/src/version.dart
@@ -1,2 +1,2 @@
 // Generated code. Do not modify.
-const packageVersion = '4.5.0';
+const packageVersion = '4.6.0';

--- a/embrace_platform_interface/pubspec.yaml
+++ b/embrace_platform_interface/pubspec.yaml
@@ -1,6 +1,6 @@
 name: embrace_platform_interface
 description: A common platform interface for the Embrace plugin that enables platform-specific implementations.
-version: 4.5.0
+version: 4.6.0
 homepage: https://embrace.io
 environment:
   sdk: ">=3.0.0 <4.0.0"


### PR DESCRIPTION
## Summary

- Bump all 5 packages to version 4.6.0
- Update inter-package dependency ranges
- Add CHANGELOG entries covering the OTel API compliance work (Phases 1–5)

## What's in this release

- OpenTelemetry API compliance: `EmbraceOTelFactory`, `EmbraceTracerProvider`, `EmbraceTracer`, `EmbraceLoggerProvider`, `EmbraceLogger`
- `addSpanExporter` / `addLogRecordExporter` for OTLP export configuration from Dart
- W3C traceparent header injection in `EmbraceHttpClient` and `EmbraceInterceptor`
- New platform methods: `setSpanStatus`, `updateSpanName`, `addSpanLink`
- Native handlers on Android and iOS for all new platform methods
- Fixed `logPushNotification` silently dropping calls when optional params are nil (iOS)

## Test plan

- [x] Dry-run CI passes (triggered by `release-candidate` label)
- [x] Manual build to device on iOS
- [x] Manual run in emulator on Android