### PR TITLE
Allow pub publish warnings in dry run

### DIFF
--- a/.github/workflows/publish_flutter_packages.yaml
+++ b/.github/workflows/publish_flutter_packages.yaml
@@ -54,7 +54,7 @@ jobs:
         run: |
           cd ${{ matrix.package }}
           flutter config --no-analytics
-          flutter pub publish --dry-run
+          flutter pub publish --dry-run || [ $? -eq 65 ]
 
       - name: Publish
         if: ${{ inputs.dry-run == false }}


### PR DESCRIPTION
## Summary

- Allow exit code 65 (warnings-only) from `flutter pub publish --dry-run` so CI does not fail on pre-release dependency warnings (e.g. `dartastic_opentelemetry_api: ^1.0.0-alpha`)

## Test plan

- [ ] Dry-run CI passes
- [ ] Merge triggers 4.6.0 release