### PR TITLE
Skip publish if package version already exists on pub.dev

### DIFF
--- a/.github/workflows/publish_flutter_packages.yaml
+++ b/.github/workflows/publish_flutter_packages.yaml
@@ -60,4 +60,11 @@ jobs:
         if: ${{ inputs.dry-run == false }}
         run: |
           cd ${{ matrix.package }}
+          PACKAGE_NAME=$(yq -r .name pubspec.yaml)
+          PACKAGE_VERSION=$(yq -r .version pubspec.yaml)
+          STATUS=$(curl -s -o /dev/null -w "%{http_code}" "https://pub.dev/api/packages/${PACKAGE_NAME}/versions/${PACKAGE_VERSION}")
+          if [ "$STATUS" = "200" ]; then
+            echo "${PACKAGE_NAME} ${PACKAGE_VERSION} is already published, skipping."
+            exit 0
+          fi
           flutter pub publish -f


### PR DESCRIPTION
## Summary

- Before publishing, check pub.dev to see if the version already exists and skip if so
- Allows the release CI to recover gracefully from partial publish runs without failing on "already exists"

## Test plan

- [ ] Dry-run CI passes
- [ ] Merge triggers 4.6.0 release, skipping already-published packages and publishing `embrace` and `embrace_dio`