### PR TITLE
feat(EMBR-11466): add EmbraceStartupTracker for time-to-first-frame

### DIFF
--- a/embrace/lib/embrace.dart
+++ b/embrace/lib/embrace.dart
@@ -4,6 +4,7 @@ import 'dart:ui';
 import 'package:dartastic_opentelemetry_api/dartastic_opentelemetry_api.dart'
     hide Severity;
 import 'package:embrace/embrace_api.dart';
+import 'package:embrace/src/embrace_startup_tracker.dart';
 import 'package:embrace/src/otel/otel.dart';
 import 'package:embrace_platform_interface/embrace_platform_interface.dart';
 import 'package:embrace_platform_interface/last_run_end_state.dart';
@@ -546,6 +547,7 @@ Future<void> _start(
   bool enableIntegrationTesting,
 ) async {
   WidgetsFlutterBinding.ensureInitialized();
+  EmbraceStartupTracker.init();
 
   if (OTelFactory.otelFactory == null) {
     OTelAPI.initialize(
@@ -565,6 +567,7 @@ Future<void> _start(
 
   if (action != null) {
     await _installErrorHandlers(action);
+    unawaited(EmbraceStartupTracker.recordFirstFrame());
   }
 }
 

--- a/embrace/lib/src/embrace_startup_tracker.dart
+++ b/embrace/lib/src/embrace_startup_tracker.dart
@@ -19,13 +19,6 @@ class EmbraceStartupTracker {
     _startEpochMs ??= DateTime.now().millisecondsSinceEpoch;
   }
 
-  /// Resets state between tests. Not for production use.
-  @visibleForTesting
-  static void resetForTesting() {
-    _stopwatch = null;
-    _startEpochMs = null;
-  }
-
   /// Waits for the first rasterized frame and records an
   /// `emb-flutter-time-to-first-frame` span covering Dart init → pixels on
   /// screen.

--- a/embrace/lib/src/embrace_startup_tracker.dart
+++ b/embrace/lib/src/embrace_startup_tracker.dart
@@ -19,6 +19,7 @@ class EmbraceStartupTracker {
     _startEpochMs ??= DateTime.now().millisecondsSinceEpoch;
   }
 
+  /// Resets state between tests. Not for production use.
   @visibleForTesting
   static void resetForTesting() {
     _stopwatch = null;

--- a/embrace/lib/src/embrace_startup_tracker.dart
+++ b/embrace/lib/src/embrace_startup_tracker.dart
@@ -8,26 +8,37 @@ import 'package:flutter/widgets.dart';
 /// changes to the app's `main` function. The end time is when the first frame
 /// is rasterized to the display, not just composed in Dart.
 class EmbraceStartupTracker {
-  static late final Stopwatch _stopwatch;
-  static late final int _startEpochMs;
+  static Stopwatch? _stopwatch;
+  static int? _startEpochMs;
 
   /// Captures the start timestamp. Must be called as early as possible in the
-  /// SDK lifecycle, before [recordFirstFrame].
+  /// SDK lifecycle, before [recordFirstFrame]. Safe to call multiple times —
+  /// only the first call sets the timestamp.
   static void init() {
-    _stopwatch = Stopwatch()..start();
-    _startEpochMs = DateTime.now().millisecondsSinceEpoch;
+    _stopwatch ??= Stopwatch()..start();
+    _startEpochMs ??= DateTime.now().millisecondsSinceEpoch;
+  }
+
+  @visibleForTesting
+  static void resetForTesting() {
+    _stopwatch = null;
+    _startEpochMs = null;
   }
 
   /// Waits for the first rasterized frame and records an
   /// `emb-flutter-time-to-first-frame` span covering Dart init → pixels on
   /// screen.
   static Future<void> recordFirstFrame() async {
+    final stopwatch = _stopwatch;
+    final startEpochMs = _startEpochMs;
+    if (stopwatch == null || startEpochMs == null) return;
+
     await WidgetsBinding.instance.waitUntilFirstFrameRasterized;
-    final elapsedMs = _stopwatch.elapsedMilliseconds;
+    final elapsedMs = stopwatch.elapsedMilliseconds;
     await EmbracePlatform.instance.recordCompletedSpan(
       'emb-flutter-time-to-first-frame',
-      _startEpochMs,
-      _startEpochMs + elapsedMs,
+      startEpochMs,
+      startEpochMs + elapsedMs,
     );
   }
 }

--- a/embrace/lib/src/embrace_startup_tracker.dart
+++ b/embrace/lib/src/embrace_startup_tracker.dart
@@ -1,0 +1,33 @@
+import 'package:embrace_platform_interface/embrace_platform_interface.dart';
+import 'package:flutter/widgets.dart';
+
+/// Measures Flutter time-to-first-frame and records it as an OTel span.
+///
+/// The start timestamp is captured when this class is first loaded by the Dart
+/// runtime — as early in the Dart lifecycle as possible without requiring
+/// changes to the app's `main` function. The end time is when the first frame
+/// is rasterized to the display, not just composed in Dart.
+class EmbraceStartupTracker {
+  static late final Stopwatch _stopwatch;
+  static late final int _startEpochMs;
+
+  /// Captures the start timestamp. Must be called as early as possible in the
+  /// SDK lifecycle, before [recordFirstFrame].
+  static void init() {
+    _stopwatch = Stopwatch()..start();
+    _startEpochMs = DateTime.now().millisecondsSinceEpoch;
+  }
+
+  /// Waits for the first rasterized frame and records an
+  /// `emb-flutter-time-to-first-frame` span covering Dart init → pixels on
+  /// screen.
+  static Future<void> recordFirstFrame() async {
+    await WidgetsBinding.instance.waitUntilFirstFrameRasterized;
+    final elapsedMs = _stopwatch.elapsedMilliseconds;
+    await EmbracePlatform.instance.recordCompletedSpan(
+      'emb-flutter-time-to-first-frame',
+      _startEpochMs,
+      _startEpochMs + elapsedMs,
+    );
+  }
+}


### PR DESCRIPTION
Records an emb-flutter-time-to-first-frame span from Dart init to the first rasterized frame using WidgetsBinding.waitUntilFirstFrameRasterized.
