### PR TITLE
feat: add TTI span instrumentation and EmbraceGoRouterObserver

### DIFF
--- a/embrace/lib/embrace.dart
+++ b/embrace/lib/embrace.dart
@@ -10,6 +10,7 @@ import 'package:embrace_platform_interface/last_run_end_state.dart';
 import 'package:flutter/widgets.dart';
 
 export 'package:embrace_platform_interface/http_method.dart' show HttpMethod;
+export 'src/go_router_observer.dart';
 export 'src/http_client.dart';
 export 'src/navigation_observer.dart';
 export 'src/otel/propagation/w3c_trace_context.dart';

--- a/embrace/lib/src/go_router_observer.dart
+++ b/embrace/lib/src/go_router_observer.dart
@@ -1,52 +1,41 @@
 import 'package:embrace/embrace.dart';
 import 'package:embrace/embrace_api.dart';
-import 'package:flutter/material.dart';
 import 'package:flutter/scheduler.dart';
+import 'package:flutter/widgets.dart';
 
-/// A function that extracts the settings from a route
-typedef EmbraceRouteSettingsExtractor = RouteSettings? Function(
-  Route<dynamic> route,
-);
-
-/// {@template embrace_navigation_observer}
-/// A [NavigatorObserver] that automatically tracks app navigation
-/// This class registers in Embrace when a view starts or stops by listening
-/// when a route is pushed or popped.
+/// {@template embrace_go_router_observer}
+/// A [NavigatorObserver] that automatically tracks app navigation for apps
+/// using go_router. Registers in Embrace when a view starts or stops by
+/// listening when a route is pushed or popped.
 ///
-/// [EmbraceNavigationObserver] should be added to the [navigationObserver](https://api.flutter.dev/flutter/material/MaterialApp/navigatorObservers.html)
-/// of [MaterialApp] or your main [Navigator].
+/// [EmbraceGoRouterObserver] should be added to the [observers](https://pub.dev/documentation/go_router/latest/go_router/GoRouter/observers.html)
+/// of your [GoRouter] instance.
 ///
 /// ```dart
-/// import 'package:flutter/material.dart';
+/// import 'package:go_router/go_router.dart';
 /// import 'package:embrace/embrace.dart';
 ///
-/// MaterialApp(
-///   navigatorObservers: [
-///     EmbraceNavigatorObserver(),
-///   ],
-///   // ...
-/// )
+/// final router = GoRouter(
+///   observers: [EmbraceGoRouterObserver()],
+///   routes: [...],
+/// );
 /// ```
 ///
-/// By default the view name is the same as the route name from its settings,
-/// but it can be modified by using a custom name extractor in
-/// [routeSettingsExtractor]
-///
-/// ```dart
-/// MaterialPageRoute(settings: RouteSettings(name: 'FirstPage'))
-/// ```
+/// By default the view name is taken from [RouteSettings.name], which for
+/// go_router is the route path. It can be overridden with
+/// [routeSettingsExtractor].
 /// {@endtemplate}
-class EmbraceNavigationObserver extends RouteObserver<ModalRoute<dynamic>> {
-  /// {@macro embrace_navigation_observer}
-  EmbraceNavigationObserver({
+class EmbraceGoRouterObserver extends NavigatorObserver {
+  /// {@macro embrace_go_router_observer}
+  EmbraceGoRouterObserver({
     EmbraceRouteSettingsExtractor? routeSettingsExtractor,
   }) : routeSettingsExtractor = routeSettingsExtractor ?? _defaultExtractor;
 
-  /// A function that returns the settings from a given route
+  /// A function that returns the settings from a given route.
   ///
-  /// If null, it returns the route default settings.
-  /// This can be used to modify the route names that are tracked by Embrace,
-  /// or return null to avoid tracking a specific view
+  /// If null, returns the route's default settings. Can be used to customise
+  /// the route names tracked by Embrace, or return null to skip tracking a
+  /// specific route.
   final EmbraceRouteSettingsExtractor? routeSettingsExtractor;
 
   static RouteSettings? _defaultExtractor(Route<dynamic> route) {
@@ -101,7 +90,6 @@ class EmbraceNavigationObserver extends RouteObserver<ModalRoute<dynamic>> {
 
   @override
   void didPush(Route<dynamic> route, Route<dynamic>? previousRoute) {
-    super.didPush(route, previousRoute);
     _updateView(route, previousRoute);
     final routeName = routeSettingsExtractor?.call(route)?.name;
     if (routeName != null) {
@@ -111,7 +99,6 @@ class EmbraceNavigationObserver extends RouteObserver<ModalRoute<dynamic>> {
 
   @override
   void didReplace({Route<dynamic>? newRoute, Route<dynamic>? oldRoute}) {
-    super.didReplace(newRoute: newRoute, oldRoute: oldRoute);
     _updateView(newRoute, oldRoute);
     final routeName =
         newRoute != null ? routeSettingsExtractor?.call(newRoute)?.name : null;
@@ -122,7 +109,6 @@ class EmbraceNavigationObserver extends RouteObserver<ModalRoute<dynamic>> {
 
   @override
   void didPop(Route<dynamic> route, Route<dynamic>? previousRoute) {
-    super.didPop(route, previousRoute);
     _updateView(previousRoute, route);
   }
 }

--- a/embrace/lib/src/go_router_observer.dart
+++ b/embrace/lib/src/go_router_observer.dart
@@ -9,7 +9,7 @@ import 'package:flutter/widgets.dart';
 /// listening when a route is pushed or popped.
 ///
 /// [EmbraceGoRouterObserver] should be added to the [observers](https://pub.dev/documentation/go_router/latest/go_router/GoRouter/observers.html)
-/// of your [GoRouter] instance.
+/// of your GoRouter instance.
 ///
 /// ```dart
 /// import 'package:go_router/go_router.dart';

--- a/embrace/test/src/go_router_observer_test.dart
+++ b/embrace/test/src/go_router_observer_test.dart
@@ -7,13 +7,13 @@ import 'package:mocktail/mocktail.dart';
 import 'observer_test_helpers.dart';
 
 void main() {
-  late EmbraceNavigationObserver observer;
+  late EmbraceGoRouterObserver observer;
 
   setUp(() {
-    observer = EmbraceNavigationObserver();
+    observer = EmbraceGoRouterObserver();
   });
 
-  group('EmbraceNavigationObserver', () {
+  group('EmbraceGoRouterObserver', () {
     group('view tracking', () {
       late MockEmbracePlatform platform;
 
@@ -23,108 +23,74 @@ void main() {
       });
 
       group('didPush', () {
-        test('ends previous view', () {
-          final route = FakeRoute(const RouteSettings(name: 'route'));
-          final previousRoute = FakeRoute(
-            const RouteSettings(name: 'previousRoute'),
-          );
-          observer.didPush(route, previousRoute);
-
-          verify(() => platform.endView('previousRoute')).called(1);
+        test('starts new view', () {
+          final route = FakeRoute(const RouteSettings(name: '/route'));
+          observer.didPush(route, null);
+          verify(() => platform.startView('/route')).called(1);
         });
 
-        test('starts new view', () {
-          final route = FakeRoute(const RouteSettings(name: 'route'));
-          final previousRoute = FakeRoute(
-            const RouteSettings(name: 'previousRoute'),
-          );
+        test('ends previous view', () {
+          final route = FakeRoute(const RouteSettings(name: '/route'));
+          final previousRoute =
+              FakeRoute(const RouteSettings(name: '/previous'));
           observer.didPush(route, previousRoute);
-
-          verify(() => platform.startView('route')).called(1);
+          verify(() => platform.endView('/previous')).called(1);
         });
 
         test('does not end view if previousRoute is null', () {
-          final route = FakeRoute(const RouteSettings(name: 'route'));
+          final route = FakeRoute(const RouteSettings(name: '/route'));
           observer.didPush(route, null);
           verifyNever(() => platform.endView(any()));
         });
 
-        test('can use custom name for starting view via routeSettingsExtractor',
-            () {
-          final observer = EmbraceNavigationObserver(
+        test('can use custom name via routeSettingsExtractor', () {
+          final observer = EmbraceGoRouterObserver(
             routeSettingsExtractor: (route) =>
                 RouteSettings(name: route.settings.name?.toUpperCase()),
           );
-          final route = FakeRoute(const RouteSettings(name: 'route'));
+          final route = FakeRoute(const RouteSettings(name: '/route'));
           observer.didPush(route, null);
-          verify(() => platform.startView('ROUTE')).called(1);
+          verify(() => platform.startView('/ROUTE')).called(1);
+        });
+      });
+
+      group('didReplace', () {
+        test('starts new view', () {
+          final newRoute = FakeRoute(const RouteSettings(name: '/new'));
+          final oldRoute = FakeRoute(const RouteSettings(name: '/old'));
+          observer.didReplace(newRoute: newRoute, oldRoute: oldRoute);
+          verify(() => platform.startView('/new')).called(1);
         });
 
-        test('can use custom name for ending view via routeSettingsExtractor',
-            () {
-          final observer = EmbraceNavigationObserver(
-            routeSettingsExtractor: (route) =>
-                RouteSettings(name: route.settings.name?.toUpperCase()),
-          );
-          final route = FakeRoute(const RouteSettings(name: 'route'));
-          final previousRoute = FakeRoute(
-            const RouteSettings(name: 'previousRoute'),
-          );
-          observer.didPush(route, previousRoute);
-          verify(() => platform.endView('PREVIOUSROUTE')).called(1);
+        test('ends old view', () {
+          final newRoute = FakeRoute(const RouteSettings(name: '/new'));
+          final oldRoute = FakeRoute(const RouteSettings(name: '/old'));
+          observer.didReplace(newRoute: newRoute, oldRoute: oldRoute);
+          verify(() => platform.endView('/old')).called(1);
         });
       });
 
       group('didPop', () {
-        test('starts back previous view', () {
-          final route = FakeRoute(const RouteSettings(name: 'route'));
-          final previousRoute = FakeRoute(
-            const RouteSettings(name: 'previousRoute'),
-          );
+        test('starts previous view', () {
+          final route = FakeRoute(const RouteSettings(name: '/route'));
+          final previousRoute =
+              FakeRoute(const RouteSettings(name: '/previous'));
           observer.didPop(route, previousRoute);
-
-          verify(() => platform.startView('previousRoute')).called(1);
+          verify(() => platform.startView('/previous')).called(1);
         });
 
         test('ends popped view', () {
-          final route = FakeRoute(const RouteSettings(name: 'route'));
-          final previousRoute = FakeRoute(
-            const RouteSettings(name: 'previousRoute'),
-          );
+          final route = FakeRoute(const RouteSettings(name: '/route'));
+          final previousRoute =
+              FakeRoute(const RouteSettings(name: '/previous'));
           observer.didPop(route, previousRoute);
-
-          verify(() => platform.endView('route')).called(1);
+          verify(() => platform.endView('/route')).called(1);
         });
 
         test('does not start view if previousRoute is null', () {
-          final route = FakeRoute(const RouteSettings(name: 'route'));
+          final route = FakeRoute(const RouteSettings(name: '/route'));
           observer.didPop(route, null);
           verifyNever(() => platform.startView(any()));
-        });
-
-        test('can use custom name for ending view via routeSettingsExtractor',
-            () {
-          final observer = EmbraceNavigationObserver(
-            routeSettingsExtractor: (route) =>
-                RouteSettings(name: route.settings.name?.toUpperCase()),
-          );
-          final route = FakeRoute(const RouteSettings(name: 'route'));
-          observer.didPop(route, null);
-          verify(() => platform.endView('ROUTE')).called(1);
-        });
-
-        test('can use custom name for starting view via routeSettingsExtractor',
-            () {
-          final observer = EmbraceNavigationObserver(
-            routeSettingsExtractor: (route) =>
-                RouteSettings(name: route.settings.name?.toUpperCase()),
-          );
-          final route = FakeRoute(const RouteSettings(name: 'route'));
-          final previousRoute = FakeRoute(
-            const RouteSettings(name: 'previousRoute'),
-          );
-          observer.didPop(route, previousRoute);
-          verify(() => platform.startView('PREVIOUSROUTE')).called(1);
         });
       });
     });
@@ -158,14 +124,14 @@ void main() {
       });
 
       testWidgets('starts a TTI span on push', (tester) async {
-        final route = FakeRoute(const RouteSettings(name: 'route'));
+        final route = FakeRoute(const RouteSettings(name: '/route'));
         observer.didPush(route, null);
         await tester.pump();
 
         verify(
           () => mockEmbrace.startSpan('emb-flutter-time-to-interactive'),
         ).called(1);
-        verify(() => mockSpan.addAttribute('route', 'route')).called(1);
+        verify(() => mockSpan.addAttribute('route', '/route')).called(1);
         verify(
           () => mockSpan.stop(endTimeMs: any(named: 'endTimeMs')),
         ).called(1);
@@ -173,15 +139,15 @@ void main() {
 
       testWidgets('TTI span uses name from routeSettingsExtractor',
           (tester) async {
-        final observer = EmbraceNavigationObserver(
+        final observer = EmbraceGoRouterObserver(
           routeSettingsExtractor: (route) =>
               RouteSettings(name: route.settings.name?.toUpperCase()),
         );
-        final route = FakeRoute(const RouteSettings(name: 'route'));
+        final route = FakeRoute(const RouteSettings(name: '/route'));
         observer.didPush(route, null);
         await tester.pump();
 
-        verify(() => mockSpan.addAttribute('route', 'ROUTE')).called(1);
+        verify(() => mockSpan.addAttribute('route', '/ROUTE')).called(1);
       });
 
       testWidgets('does not start a TTI span when route name is null',
@@ -194,14 +160,14 @@ void main() {
       });
 
       testWidgets('starts a TTI span on replace', (tester) async {
-        final newRoute = FakeRoute(const RouteSettings(name: 'route'));
+        final newRoute = FakeRoute(const RouteSettings(name: '/new'));
         observer.didReplace(newRoute: newRoute, oldRoute: null);
         await tester.pump();
 
         verify(
           () => mockEmbrace.startSpan('emb-flutter-time-to-interactive'),
         ).called(1);
-        verify(() => mockSpan.addAttribute('route', 'route')).called(1);
+        verify(() => mockSpan.addAttribute('route', '/new')).called(1);
         verify(
           () => mockSpan.stop(endTimeMs: any(named: 'endTimeMs')),
         ).called(1);
@@ -209,7 +175,7 @@ void main() {
 
       testWidgets('does not start a TTI span when newRoute is null on replace',
           (tester) async {
-        final oldRoute = FakeRoute(const RouteSettings(name: 'route'));
+        final oldRoute = FakeRoute(const RouteSettings(name: '/old'));
         observer.didReplace(newRoute: null, oldRoute: oldRoute);
         await tester.pump();
 
@@ -217,9 +183,8 @@ void main() {
       });
 
       testWidgets('does not start a TTI span on pop', (tester) async {
-        final route = FakeRoute(const RouteSettings(name: 'route'));
-        final previousRoute =
-            FakeRoute(const RouteSettings(name: 'previousRoute'));
+        final route = FakeRoute(const RouteSettings(name: '/route'));
+        final previousRoute = FakeRoute(const RouteSettings(name: '/previous'));
         observer.didPop(route, previousRoute);
         await tester.pump();
 

--- a/embrace/test/src/go_router_observer_test.dart
+++ b/embrace/test/src/go_router_observer_test.dart
@@ -7,13 +7,13 @@ import 'package:mocktail/mocktail.dart';
 import 'observer_test_helpers.dart';
 
 void main() {
-  late EmbraceNavigationObserver observer;
+  late EmbraceGoRouterObserver observer;
 
   setUp(() {
-    observer = EmbraceNavigationObserver();
+    observer = EmbraceGoRouterObserver();
   });
 
-  group('EmbraceNavigationObserver', () {
+  group('EmbraceGoRouterObserver', () {
     group('view tracking', () {
       late MockEmbracePlatform platform;
 
@@ -23,108 +23,74 @@ void main() {
       });
 
       group('didPush', () {
-        test('ends previous view', () {
-          final route = FakeRoute(const RouteSettings(name: 'route'));
-          final previousRoute = FakeRoute(
-            const RouteSettings(name: 'previousRoute'),
-          );
-          observer.didPush(route, previousRoute);
-
-          verify(() => platform.endView('previousRoute')).called(1);
+        test('starts new view', () {
+          final route = FakeRoute(const RouteSettings(name: '/route'));
+          observer.didPush(route, null);
+          verify(() => platform.startView('/route')).called(1);
         });
 
-        test('starts new view', () {
-          final route = FakeRoute(const RouteSettings(name: 'route'));
-          final previousRoute = FakeRoute(
-            const RouteSettings(name: 'previousRoute'),
-          );
+        test('ends previous view', () {
+          final route = FakeRoute(const RouteSettings(name: '/route'));
+          final previousRoute =
+              FakeRoute(const RouteSettings(name: '/previous'));
           observer.didPush(route, previousRoute);
-
-          verify(() => platform.startView('route')).called(1);
+          verify(() => platform.endView('/previous')).called(1);
         });
 
         test('does not end view if previousRoute is null', () {
-          final route = FakeRoute(const RouteSettings(name: 'route'));
+          final route = FakeRoute(const RouteSettings(name: '/route'));
           observer.didPush(route, null);
           verifyNever(() => platform.endView(any()));
         });
 
-        test('can use custom name for starting view via routeSettingsExtractor',
-            () {
-          final observer = EmbraceNavigationObserver(
+        test('can use custom name via routeSettingsExtractor', () {
+          final observer = EmbraceGoRouterObserver(
             routeSettingsExtractor: (route) =>
                 RouteSettings(name: route.settings.name?.toUpperCase()),
           );
-          final route = FakeRoute(const RouteSettings(name: 'route'));
+          final route = FakeRoute(const RouteSettings(name: '/route'));
           observer.didPush(route, null);
-          verify(() => platform.startView('ROUTE')).called(1);
+          verify(() => platform.startView('/ROUTE')).called(1);
+        });
+      });
+
+      group('didReplace', () {
+        test('starts new view', () {
+          final newRoute = FakeRoute(const RouteSettings(name: '/new'));
+          final oldRoute = FakeRoute(const RouteSettings(name: '/old'));
+          observer.didReplace(newRoute: newRoute, oldRoute: oldRoute);
+          verify(() => platform.startView('/new')).called(1);
         });
 
-        test('can use custom name for ending view via routeSettingsExtractor',
-            () {
-          final observer = EmbraceNavigationObserver(
-            routeSettingsExtractor: (route) =>
-                RouteSettings(name: route.settings.name?.toUpperCase()),
-          );
-          final route = FakeRoute(const RouteSettings(name: 'route'));
-          final previousRoute = FakeRoute(
-            const RouteSettings(name: 'previousRoute'),
-          );
-          observer.didPush(route, previousRoute);
-          verify(() => platform.endView('PREVIOUSROUTE')).called(1);
+        test('ends old view', () {
+          final newRoute = FakeRoute(const RouteSettings(name: '/new'));
+          final oldRoute = FakeRoute(const RouteSettings(name: '/old'));
+          observer.didReplace(newRoute: newRoute, oldRoute: oldRoute);
+          verify(() => platform.endView('/old')).called(1);
         });
       });
 
       group('didPop', () {
-        test('starts back previous view', () {
-          final route = FakeRoute(const RouteSettings(name: 'route'));
-          final previousRoute = FakeRoute(
-            const RouteSettings(name: 'previousRoute'),
-          );
+        test('starts previous view', () {
+          final route = FakeRoute(const RouteSettings(name: '/route'));
+          final previousRoute =
+              FakeRoute(const RouteSettings(name: '/previous'));
           observer.didPop(route, previousRoute);
-
-          verify(() => platform.startView('previousRoute')).called(1);
+          verify(() => platform.startView('/previous')).called(1);
         });
 
         test('ends popped view', () {
-          final route = FakeRoute(const RouteSettings(name: 'route'));
-          final previousRoute = FakeRoute(
-            const RouteSettings(name: 'previousRoute'),
-          );
+          final route = FakeRoute(const RouteSettings(name: '/route'));
+          final previousRoute =
+              FakeRoute(const RouteSettings(name: '/previous'));
           observer.didPop(route, previousRoute);
-
-          verify(() => platform.endView('route')).called(1);
+          verify(() => platform.endView('/route')).called(1);
         });
 
         test('does not start view if previousRoute is null', () {
-          final route = FakeRoute(const RouteSettings(name: 'route'));
+          final route = FakeRoute(const RouteSettings(name: '/route'));
           observer.didPop(route, null);
           verifyNever(() => platform.startView(any()));
-        });
-
-        test('can use custom name for ending view via routeSettingsExtractor',
-            () {
-          final observer = EmbraceNavigationObserver(
-            routeSettingsExtractor: (route) =>
-                RouteSettings(name: route.settings.name?.toUpperCase()),
-          );
-          final route = FakeRoute(const RouteSettings(name: 'route'));
-          observer.didPop(route, null);
-          verify(() => platform.endView('ROUTE')).called(1);
-        });
-
-        test('can use custom name for starting view via routeSettingsExtractor',
-            () {
-          final observer = EmbraceNavigationObserver(
-            routeSettingsExtractor: (route) =>
-                RouteSettings(name: route.settings.name?.toUpperCase()),
-          );
-          final route = FakeRoute(const RouteSettings(name: 'route'));
-          final previousRoute = FakeRoute(
-            const RouteSettings(name: 'previousRoute'),
-          );
-          observer.didPop(route, previousRoute);
-          verify(() => platform.startView('PREVIOUSROUTE')).called(1);
         });
       });
     });
@@ -158,14 +124,14 @@ void main() {
       });
 
       testWidgets('starts a TTI span on push', (tester) async {
-        final route = FakeRoute(const RouteSettings(name: 'route'));
+        final route = FakeRoute(const RouteSettings(name: '/route'));
         observer.didPush(route, null);
         await tester.pump();
 
         verify(
           () => mockEmbrace.startSpan('emb-flutter-time-to-interactive'),
         ).called(1);
-        verify(() => mockSpan.addAttribute('route', 'route')).called(1);
+        verify(() => mockSpan.addAttribute('route', '/route')).called(1);
         verify(
           () => mockSpan.stop(endTimeMs: any(named: 'endTimeMs')),
         ).called(1);
@@ -173,15 +139,15 @@ void main() {
 
       testWidgets('TTI span uses name from routeSettingsExtractor',
           (tester) async {
-        final observer = EmbraceNavigationObserver(
+        final observer = EmbraceGoRouterObserver(
           routeSettingsExtractor: (route) =>
               RouteSettings(name: route.settings.name?.toUpperCase()),
         );
-        final route = FakeRoute(const RouteSettings(name: 'route'));
+        final route = FakeRoute(const RouteSettings(name: '/route'));
         observer.didPush(route, null);
         await tester.pump();
 
-        verify(() => mockSpan.addAttribute('route', 'ROUTE')).called(1);
+        verify(() => mockSpan.addAttribute('route', '/ROUTE')).called(1);
       });
 
       testWidgets('does not start a TTI span when route name is null',
@@ -194,14 +160,14 @@ void main() {
       });
 
       testWidgets('starts a TTI span on replace', (tester) async {
-        final newRoute = FakeRoute(const RouteSettings(name: 'route'));
+        final newRoute = FakeRoute(const RouteSettings(name: '/new'));
         observer.didReplace(newRoute: newRoute, oldRoute: null);
         await tester.pump();
 
         verify(
           () => mockEmbrace.startSpan('emb-flutter-time-to-interactive'),
         ).called(1);
-        verify(() => mockSpan.addAttribute('route', 'route')).called(1);
+        verify(() => mockSpan.addAttribute('route', '/new')).called(1);
         verify(
           () => mockSpan.stop(endTimeMs: any(named: 'endTimeMs')),
         ).called(1);
@@ -209,7 +175,7 @@ void main() {
 
       testWidgets('does not start a TTI span when newRoute is null on replace',
           (tester) async {
-        final oldRoute = FakeRoute(const RouteSettings(name: 'route'));
+        final oldRoute = FakeRoute(const RouteSettings(name: '/old'));
         observer.didReplace(newRoute: null, oldRoute: oldRoute);
         await tester.pump();
 
@@ -217,9 +183,9 @@ void main() {
       });
 
       testWidgets('does not start a TTI span on pop', (tester) async {
-        final route = FakeRoute(const RouteSettings(name: 'route'));
+        final route = FakeRoute(const RouteSettings(name: '/route'));
         final previousRoute =
-            FakeRoute(const RouteSettings(name: 'previousRoute'));
+            FakeRoute(const RouteSettings(name: '/previous'));
         observer.didPop(route, previousRoute);
         await tester.pump();
 

--- a/embrace/test/src/go_router_observer_test.dart
+++ b/embrace/test/src/go_router_observer_test.dart
@@ -184,8 +184,7 @@ void main() {
 
       testWidgets('does not start a TTI span on pop', (tester) async {
         final route = FakeRoute(const RouteSettings(name: '/route'));
-        final previousRoute =
-            FakeRoute(const RouteSettings(name: '/previous'));
+        final previousRoute = FakeRoute(const RouteSettings(name: '/previous'));
         observer.didPop(route, previousRoute);
         await tester.pump();
 

--- a/embrace/test/src/go_router_observer_test.dart
+++ b/embrace/test/src/go_router_observer_test.dart
@@ -161,7 +161,7 @@ void main() {
 
       testWidgets('starts a TTI span on replace', (tester) async {
         final newRoute = FakeRoute(const RouteSettings(name: '/new'));
-        observer.didReplace(newRoute: newRoute, oldRoute: null);
+        observer.didReplace(newRoute: newRoute);
         await tester.pump();
 
         verify(
@@ -176,7 +176,7 @@ void main() {
       testWidgets('does not start a TTI span when newRoute is null on replace',
           (tester) async {
         final oldRoute = FakeRoute(const RouteSettings(name: '/old'));
-        observer.didReplace(newRoute: null, oldRoute: oldRoute);
+        observer.didReplace(oldRoute: oldRoute);
         await tester.pump();
 
         verifyNever(() => mockEmbrace.startSpan(any()));

--- a/embrace/test/src/navigation_observer_test.dart
+++ b/embrace/test/src/navigation_observer_test.dart
@@ -195,7 +195,7 @@ void main() {
 
       testWidgets('starts a TTI span on replace', (tester) async {
         final newRoute = FakeRoute(const RouteSettings(name: 'route'));
-        observer.didReplace(newRoute: newRoute, oldRoute: null);
+        observer.didReplace(newRoute: newRoute);
         await tester.pump();
 
         verify(
@@ -210,7 +210,7 @@ void main() {
       testWidgets('does not start a TTI span when newRoute is null on replace',
           (tester) async {
         final oldRoute = FakeRoute(const RouteSettings(name: 'route'));
-        observer.didReplace(newRoute: null, oldRoute: oldRoute);
+        observer.didReplace(oldRoute: oldRoute);
         await tester.pump();
 
         verifyNever(() => mockEmbrace.startSpan(any()));

--- a/embrace/test/src/observer_test_helpers.dart
+++ b/embrace/test/src/observer_test_helpers.dart
@@ -1,0 +1,27 @@
+import 'package:embrace/embrace.dart';
+import 'package:embrace/embrace_api.dart';
+import 'package:embrace_platform_interface/embrace_platform_interface.dart';
+import 'package:flutter/material.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:plugin_platform_interface/plugin_platform_interface.dart';
+
+class MockEmbracePlatform extends Mock
+    with MockPlatformInterfaceMixin
+    implements EmbracePlatform {}
+
+class MockEmbrace extends Mock implements Embrace {}
+
+class MockEmbraceSpan extends Mock implements EmbraceSpan {
+  @override
+  String get id => 'mock-span-id';
+
+  @override
+  Future<String?> get traceId => Future.value(null);
+}
+
+class FakeRoute extends Fake implements Route<dynamic> {
+  FakeRoute(this.settings);
+
+  @override
+  final RouteSettings settings;
+}

--- a/embrace/test/src/observer_test_helpers.dart
+++ b/embrace/test/src/observer_test_helpers.dart
@@ -16,7 +16,7 @@ class MockEmbraceSpan extends Mock implements EmbraceSpan {
   String get id => 'mock-span-id';
 
   @override
-  Future<String?> get traceId => Future.value(null);
+  Future<String?> get traceId => Future.value();
 }
 
 class FakeRoute extends Fake implements Route<dynamic> {


### PR DESCRIPTION
- EmbraceNavigationObserver now starts a TTI span on didPush and didReplace
- New EmbraceGoRouterObserver for apps using go_router, with view tracking and TTI spans on didPush and didReplace
- Shared test helpers extracted to observer_test_helpers.dart