### PR TITLE
feat: add EmbraceLifecycleObserver to track app background spans

### DIFF
--- a/embrace/lib/embrace.dart
+++ b/embrace/lib/embrace.dart
@@ -5,6 +5,7 @@ import 'package:dartastic_opentelemetry_api/dartastic_opentelemetry_api.dart'
     hide Severity;
 import 'package:embrace/embrace_api.dart';
 import 'package:embrace/src/embrace_startup_tracker.dart';
+import 'package:embrace/src/lifecycle_observer.dart';
 import 'package:embrace/src/otel/otel.dart';
 import 'package:embrace_platform_interface/embrace_platform_interface.dart';
 import 'package:embrace_platform_interface/last_run_end_state.dart';
@@ -13,6 +14,7 @@ import 'package:flutter/widgets.dart';
 export 'package:embrace_platform_interface/http_method.dart' show HttpMethod;
 export 'src/go_router_observer.dart';
 export 'src/http_client.dart';
+export 'src/lifecycle_observer.dart';
 export 'src/navigation_observer.dart';
 export 'src/otel/propagation/w3c_trace_context.dart';
 
@@ -565,6 +567,8 @@ Future<void> _start(
   await EmbracePlatform.instance.attachToHostSdk(
     enableIntegrationTesting: enableIntegrationTesting,
   );
+
+  WidgetsBinding.instance.addObserver(EmbraceLifecycleObserver());
 
   if (action != null) {
     await _installErrorHandlers(action);

--- a/embrace/lib/src/lifecycle_observer.dart
+++ b/embrace/lib/src/lifecycle_observer.dart
@@ -1,0 +1,57 @@
+import 'dart:async';
+
+import 'package:embrace/embrace.dart';
+import 'package:embrace/embrace_api.dart';
+import 'package:flutter/widgets.dart';
+
+/// A [WidgetsBindingObserver] that tracks app foreground/background lifecycle.
+class EmbraceLifecycleObserver with WidgetsBindingObserver {
+  EmbraceSpan? _backgroundSpan;
+  bool _isBackground = false;
+
+  @override
+  void didChangeAppLifecycleState(AppLifecycleState state) {
+    switch (state) {
+      case AppLifecycleState.paused:
+        _onPaused();
+      case AppLifecycleState.resumed:
+        _onResumed();
+      case AppLifecycleState.detached:
+        _onDetached();
+      case _:
+        break;
+    }
+  }
+
+  void _onPaused() {
+    if (_isBackground) return;
+    _isBackground = true;
+    Embrace.instance.startSpan('emb-app-background').then(
+      (span) {
+        _backgroundSpan = span;
+        if (!_isBackground) {
+          _stopBackgroundSpan();
+        }
+      },
+      onError: (_, __) {},
+    );
+  }
+
+  void _onResumed() {
+    _isBackground = false;
+    _stopBackgroundSpan();
+  }
+
+  void _onDetached() {
+    _isBackground = false;
+    _stopBackgroundSpan();
+  }
+
+  void _stopBackgroundSpan() {
+    final span = _backgroundSpan;
+    _backgroundSpan = null;
+    if (span != null) {
+      unawaited(span.stop());
+    }
+  }
+}

--- a/embrace/test/src/lifecycle_observer_test.dart
+++ b/embrace/test/src/lifecycle_observer_test.dart
@@ -1,0 +1,101 @@
+import 'package:embrace/embrace.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+
+import 'observer_test_helpers.dart';
+
+void main() {
+  late EmbraceLifecycleObserver observer;
+  late MockEmbrace mockEmbrace;
+  late MockEmbraceSpan mockSpan;
+
+  setUpAll(() {
+    registerFallbackValue('');
+  });
+
+  setUp(() {
+    mockEmbrace = MockEmbrace();
+    mockSpan = MockEmbraceSpan();
+    // ignore: invalid_use_of_visible_for_testing_member
+    debugEmbraceOverride = mockEmbrace;
+    when(() => mockEmbrace.startSpan('emb-app-background'))
+        .thenAnswer((_) => Future.value(mockSpan));
+    when(mockSpan.stop).thenAnswer((_) async => true);
+    observer = EmbraceLifecycleObserver();
+  });
+
+  tearDown(() {
+    // ignore: invalid_use_of_visible_for_testing_member
+    debugEmbraceOverride = null;
+  });
+
+  group('EmbraceLifecycleObserver', () {
+    test('starts background span on paused', () async {
+      observer.didChangeAppLifecycleState(AppLifecycleState.paused);
+      await Future<void>.value();
+
+      verify(() => mockEmbrace.startSpan('emb-app-background')).called(1);
+    });
+
+    test('stops background span on resumed after paused', () async {
+      observer.didChangeAppLifecycleState(AppLifecycleState.paused);
+      await Future<void>.value();
+      observer.didChangeAppLifecycleState(AppLifecycleState.resumed);
+
+      verify(mockSpan.stop).called(1);
+    });
+
+    test('stops background span on detached after paused', () async {
+      observer.didChangeAppLifecycleState(AppLifecycleState.paused);
+      await Future<void>.value();
+      observer.didChangeAppLifecycleState(AppLifecycleState.detached);
+
+      verify(mockSpan.stop).called(1);
+    });
+
+    test('does not stop span when resumed with no prior pause', () {
+      observer.didChangeAppLifecycleState(AppLifecycleState.resumed);
+      verifyNever(mockSpan.stop);
+    });
+
+    test('does not start background span on inactive', () {
+      observer.didChangeAppLifecycleState(AppLifecycleState.inactive);
+      verifyNever(() => mockEmbrace.startSpan(any()));
+    });
+
+    test(
+      'stops span immediately if resumed before startSpan resolves',
+      () async {
+        observer
+          ..didChangeAppLifecycleState(AppLifecycleState.paused)
+          ..didChangeAppLifecycleState(AppLifecycleState.resumed);
+        await Future<void>.value();
+
+        verify(mockSpan.stop).called(1);
+      },
+    );
+
+    test(
+      'does not start duplicate background span on repeated paused',
+      () async {
+        observer.didChangeAppLifecycleState(AppLifecycleState.paused);
+        await Future<void>.value();
+        observer.didChangeAppLifecycleState(AppLifecycleState.paused);
+        await Future<void>.value();
+
+        verify(() => mockEmbrace.startSpan('emb-app-background')).called(1);
+      },
+    );
+
+    test('stops background span when resumed after repeated paused', () async {
+      observer.didChangeAppLifecycleState(AppLifecycleState.paused);
+      await Future<void>.value();
+      observer.didChangeAppLifecycleState(AppLifecycleState.paused);
+      await Future<void>.value();
+      observer.didChangeAppLifecycleState(AppLifecycleState.resumed);
+
+      verify(mockSpan.stop).called(1);
+    });
+  });
+}


### PR DESCRIPTION
Registers a WidgetsBindingObserver on Embrace.start() that opens an emb-app-background span when the app is paused and stops it on resume or detach. Guards against duplicate spans on repeated pause events and uses unawaited() consistently for fire-and-forget span stops.

