### PR TITLE
fix(otel): remove deprecated Context.current setter usage

### DIFF
--- a/embrace/lib/src/otel/context/otel_context_utils.dart
+++ b/embrace/lib/src/otel/context/otel_context_utils.dart
@@ -9,20 +9,6 @@ import 'package:meta/meta.dart';
 class OTelContextUtils {
   OTelContextUtils._();
 
-  /// Makes [span] the active span in [Context.current] and returns the
-  /// context that was active before the push.
-  static Context attachSpan(APISpan span) {
-    final previous = Context.current;
-    Context.current = previous.withSpan(span);
-    return previous;
-  }
-
-  /// Restores a previously saved context as [Context.current].
-  // ignore: use_setters_to_change_properties
-  static void restore(Context previous) {
-    Context.current = previous;
-  }
-
   /// Returns the span currently active in [Context.current], or `null` if
   /// no span is active or OTel has not been initialized.
   static APISpan? currentSpan() {

--- a/embrace/lib/src/otel/tracing/embrace_otel_span.dart
+++ b/embrace/lib/src/otel/tracing/embrace_otel_span.dart
@@ -2,7 +2,6 @@ import 'dart:async';
 
 import 'package:dartastic_opentelemetry_api/dartastic_opentelemetry_api.dart'
     as otel;
-import 'package:embrace/src/otel/context/otel_context_utils.dart';
 import 'package:embrace_platform_interface/embrace_platform_interface.dart';
 import 'package:meta/meta.dart';
 
@@ -20,15 +19,11 @@ class EmbraceOTelSpan implements otel.APISpan {
   /// Creates an [EmbraceOTelSpan].
   ///
   /// [nativeSpanId] is the [Future] returned by [EmbracePlatform.startSpan].
-  /// [previousContext] is the [otel.Context] that was active before this span
-  /// was made current; [end] restores it. Pass `null` for spans created via
-  /// [otel.APITracer.createSpan] that are never attached to context.
   EmbraceOTelSpan({
     required String name,
     required Future<String?> nativeSpanId,
     required otel.SpanContext spanContext,
     required otel.InstrumentationScope instrumentationScope,
-    otel.Context? previousContext,
     otel.APISpan? parentSpan,
     otel.SpanKind kind = otel.SpanKind.internal,
     DateTime? startTime,
@@ -36,7 +31,6 @@ class EmbraceOTelSpan implements otel.APISpan {
         _nativeSpanId = nativeSpanId,
         _spanContext = spanContext,
         _instrumentationScope = instrumentationScope,
-        _previousContext = previousContext,
         _parentSpan = parentSpan,
         _kind = kind,
         _startTime = startTime ?? DateTime.now();
@@ -45,7 +39,6 @@ class EmbraceOTelSpan implements otel.APISpan {
   final Future<String?> _nativeSpanId;
   final otel.SpanContext _spanContext;
   final otel.InstrumentationScope _instrumentationScope;
-  final otel.Context? _previousContext;
   final otel.APISpan? _parentSpan;
   final otel.SpanKind _kind;
   final DateTime _startTime;
@@ -325,7 +318,6 @@ class EmbraceOTelSpan implements otel.APISpan {
         ),
       ),
     );
-    if (_previousContext != null) OTelContextUtils.restore(_previousContext!);
   }
 
   // ── Helpers ────────────────────────────────────────────────────────────────

--- a/embrace/lib/src/otel/tracing/embrace_tracer.dart
+++ b/embrace/lib/src/otel/tracing/embrace_tracer.dart
@@ -55,12 +55,6 @@ class EmbraceTracer implements APITracer {
       );
     }
 
-    // Capture the active context before the span exists so it can be stored
-    // on the span for restoration in end(). OTelContextUtils.attachSpan also
-    // captures Context.current internally, so its return value would equal
-    // previousContext — but the span must be constructed first, making this
-    // ordering unavoidable.
-    final previousContext = Context.current;
     final effectiveContext = context ?? Context.current;
     final otelSpanContext = _buildSpanContext(
       parentSpan: parentSpan,
@@ -79,7 +73,6 @@ class EmbraceTracer implements APITracer {
       nativeSpanId: nativeSpanId,
       spanContext: otelSpanContext,
       instrumentationScope: _instrumentationScope,
-      previousContext: previousContext,
       parentSpan: parentSpan,
       kind: kind,
     );
@@ -87,7 +80,6 @@ class EmbraceTracer implements APITracer {
     if (attributes != null) span.addAttributes(attributes);
     links?.forEach(span.addSpanLink);
 
-    OTelContextUtils.attachSpan(span);
     return span;
   }
 
@@ -169,14 +161,8 @@ class EmbraceTracer implements APITracer {
   APISpan? get currentSpan => OTelContextUtils.currentSpan();
 
   @override
-  T withSpan<T>(APISpan span, T Function() fn) {
-    final previous = OTelContextUtils.attachSpan(span);
-    try {
-      return fn();
-    } finally {
-      OTelContextUtils.restore(previous);
-    }
-  }
+  T withSpan<T>(APISpan span, T Function() fn) =>
+      Context.current.withSpan(span).runSync(fn);
 
   @override
   Future<T> withSpanAsync<T>(APISpan span, Future<T> Function() fn) =>

--- a/embrace/test/src/http_client_test.dart
+++ b/embrace/test/src/http_client_test.dart
@@ -155,7 +155,9 @@ void main() {
 
         when(() => response.statusCode).thenReturn(200);
         final embraceClient = EmbraceHttpClient(internalClient: client);
-        await embraceClient.get(Uri.parse('https://embrace.io'));
+        await tracer.withSpanAsync(span, () async {
+          await embraceClient.get(Uri.parse('https://embrace.io'));
+        });
 
         verify(
           () => embracePlatform.logNetworkRequest(
@@ -203,7 +205,9 @@ void main() {
 
         when(() => response.statusCode).thenReturn(200);
         final embraceClient = EmbraceHttpClient(internalClient: client);
-        await embraceClient.get(Uri.parse('https://embrace.io'));
+        await tracer.withSpanAsync(span, () async {
+          await embraceClient.get(Uri.parse('https://embrace.io'));
+        });
 
         verify(
           () => embracePlatform.logNetworkRequest(

--- a/embrace/test/src/otel/context/otel_context_utils_test.dart
+++ b/embrace/test/src/otel/context/otel_context_utils_test.dart
@@ -54,49 +54,34 @@ void main() {
       expect(OTelContextUtils.currentSpan(), isNull);
     });
 
-    test('attachSpan makes span current in Context', () {
-      // createSpan does not push to context, so Context.current is unaffected.
+    test('currentSpan() returns span inside withSpan', () {
       final span = tracer.createSpan(name: 'test');
 
-      OTelContextUtils.attachSpan(span);
-
-      expect(OTelContextUtils.currentSpan(), same(span));
+      tracer.withSpan(span, () {
+        expect(OTelContextUtils.currentSpan(), same(span));
+      });
     });
 
-    test('attachSpan returns the previous Context', () {
+    test('currentSpan() returns null outside withSpan', () {
       final span = tracer.createSpan(name: 'test');
-      final before = Context.current;
-
-      final returned = OTelContextUtils.attachSpan(span);
-
-      expect(returned, same(before));
-    });
-
-    test('restore reverts Context.current to the previous Context', () {
-      final span = tracer.createSpan(name: 'test');
-      final previous = OTelContextUtils.attachSpan(span);
-
-      OTelContextUtils.restore(previous);
+      tracer.withSpan(span, () {});
 
       expect(OTelContextUtils.currentSpan(), isNull);
-    });
-
-    test('currentSpan() returns span after attachSpan', () {
-      final span = tracer.createSpan(name: 'test');
-      OTelContextUtils.attachSpan(span);
-
-      expect(OTelContextUtils.currentSpan(), same(span));
     });
 
     test('currentSpanContext() returns null when no span is active', () {
       expect(OTelContextUtils.currentSpanContext(), isNull);
     });
 
-    test('currentSpanContext() returns spanContext after attachSpan', () {
+    test('currentSpanContext() returns spanContext inside withSpan', () {
       final span = tracer.createSpan(name: 'test');
-      OTelContextUtils.attachSpan(span);
 
-      expect(OTelContextUtils.currentSpanContext(), equals(span.spanContext));
+      tracer.withSpan(span, () {
+        expect(
+          OTelContextUtils.currentSpanContext(),
+          equals(span.spanContext),
+        );
+      });
     });
   });
 }

--- a/embrace/test/src/otel/propagation/w3c_trace_context_test.dart
+++ b/embrace/test/src/otel/propagation/w3c_trace_context_test.dart
@@ -157,7 +157,9 @@ void main() {
       );
       final headers = <String, String>{};
 
-      await W3cTraceContext.injectCurrent(headers);
+      await tracer.withSpanAsync(span, () async {
+        await W3cTraceContext.injectCurrent(headers);
+      });
 
       verify(
         () => platform.generateW3cTraceparent(
@@ -176,7 +178,9 @@ void main() {
       _stubGenerateW3cTraceparent(platform, platformValue);
       final headers = <String, String>{};
 
-      await W3cTraceContext.injectCurrent(headers);
+      await tracer.withSpanAsync(span, () async {
+        await W3cTraceContext.injectCurrent(headers);
+      });
 
       expect(headers['traceparent'], platformValue);
 
@@ -189,7 +193,9 @@ void main() {
       _stubGenerateW3cTraceparent(platform, null);
       final headers = <String, String>{};
 
-      await W3cTraceContext.injectCurrent(headers);
+      await tracer.withSpanAsync(span, () async {
+        await W3cTraceContext.injectCurrent(headers);
+      });
 
       verify(
         () => platform.generateW3cTraceparent(
@@ -218,7 +224,9 @@ void main() {
       final sc = span.spanContext;
       final headers = <String, String>{};
 
-      W3cTraceContext.injectCurrentSync(headers);
+      tracer.withSpan(span, () {
+        W3cTraceContext.injectCurrentSync(headers);
+      });
 
       expect(headers['traceparent'], W3cTraceContext.fromSpanContext(sc));
       verifyNever(() => platform.generateW3cTraceparent(any(), any()));

--- a/embrace/test/src/otel/tracing/embrace_tracer_test.dart
+++ b/embrace/test/src/otel/tracing/embrace_tracer_test.dart
@@ -309,32 +309,30 @@ void main() {
       ).thenAnswer((_) async => true);
     });
 
-    test('startSpan makes span current in context', () {
-      final span = tracer.startSpan('op');
-
-      expect(OTelContextUtils.currentSpan(), same(span));
-    });
-
-    test('after span.end(), previous span is current again', () {
-      final span = tracer.startSpan('op');
-      expect(OTelContextUtils.currentSpan(), same(span));
-
-      span.end();
+    test('startSpan does not set span as current in context', () {
+      tracer.startSpan('op');
 
       expect(OTelContextUtils.currentSpan(), isNull);
     });
 
-    test('nested startSpan produces correct parent chain', () {
+    test('nested withSpan produces correct context stack', () {
       final parent = tracer.startSpan('parent');
       final child = tracer.startSpan('child');
 
-      expect(OTelContextUtils.currentSpan(), same(child));
+      tracer.withSpan(parent, () {
+        expect(OTelContextUtils.currentSpan(), same(parent));
+
+        tracer.withSpan(child, () {
+          expect(OTelContextUtils.currentSpan(), same(child));
+        });
+
+        expect(OTelContextUtils.currentSpan(), same(parent));
+      });
+
+      expect(OTelContextUtils.currentSpan(), isNull);
 
       child.end();
-      expect(OTelContextUtils.currentSpan(), same(parent));
-
       parent.end();
-      expect(OTelContextUtils.currentSpan(), isNull);
     });
 
     test('createSpan does not push span to context', () {
@@ -379,10 +377,12 @@ void main() {
       expect(tracer.currentSpan, isNull);
     });
 
-    test('currentSpan reflects the active span', () {
+    test('currentSpan reflects the active span during withSpan', () {
       final span = tracer.startSpan('op');
 
-      expect(tracer.currentSpan, same(span));
+      tracer.withSpan(span, () {
+        expect(tracer.currentSpan, same(span));
+      });
     });
   });
 }


### PR DESCRIPTION
Migrates away from the imperative Context.current setter (deprecated in dartastic_opentelemetry_api 1.0.0-beta.1, to be removed in 1.0.0) by aligning with OTel spec behaviour:

- withSpan now uses Context.runSync(), propagating context via Zones rather than a global setter.
- startSpan no longer auto-makes the new span current in the context; callers use withSpan/withSpanAsync explicitly. This matches the OTel spec, which says startSpan SHOULD NOT set the active span.
- attachSpan and restore are deleted from OTelContextUtils.
- _previousContext is removed from EmbraceOTelSpan.
- Tests updated throughout to use withSpan/withSpanAsync where a span needs to be active.

