### PR TITLE
fix(otel): implement timeProvider for dartastic_opentelemetry_api beta.6 compatibility

### DIFF
--- a/embrace/lib/src/otel/tracing/embrace_tracer.dart
+++ b/embrace/lib/src/otel/tracing/embrace_tracer.dart
@@ -161,6 +161,9 @@ class EmbraceTracer implements APITracer {
   APISpan? get currentSpan => OTelContextUtils.currentSpan();
 
   @override
+  TimeProvider get timeProvider => _delegate.timeProvider;
+
+  @override
   T withSpan<T>(APISpan span, T Function() fn) =>
       Context.current.withSpan(span).runSync(fn);
 

--- a/embrace/lib/src/otel/tracing/embrace_tracer_provider.dart
+++ b/embrace/lib/src/otel/tracing/embrace_tracer_provider.dart
@@ -37,6 +37,7 @@ class EmbraceTracerProvider implements APITracerProvider {
   String? _serviceVersion;
   bool _enabled;
   bool _isShutdown;
+  TimeProvider _timeProvider = defaultTimeProvider;
 
   final List<_SpanExporterConfig> _pendingSpanExporters = [];
 
@@ -120,6 +121,12 @@ class EmbraceTracerProvider implements APITracerProvider {
 
   @override
   set serviceVersion(String? value) => _serviceVersion = value;
+
+  @override
+  TimeProvider get timeProvider => _timeProvider;
+
+  @override
+  set timeProvider(TimeProvider value) => _timeProvider = value;
 
   @override
   bool get enabled => _enabled;

--- a/embrace/test/src/http_client_test.dart
+++ b/embrace/test/src/http_client_test.dart
@@ -1,4 +1,5 @@
-import 'package:dartastic_opentelemetry_api/dartastic_opentelemetry_api.dart';
+import 'package:dartastic_opentelemetry_api/dartastic_opentelemetry_api.dart'
+    hide Client;
 import 'package:embrace/embrace.dart';
 import 'package:embrace_platform_interface/embrace_platform_interface.dart';
 import 'package:flutter_test/flutter_test.dart';


### PR DESCRIPTION
## Summary

- `dartastic_opentelemetry_api` `beta.6` added `timeProvider` to `APITracer` and `APITracerProvider`; without a committed lock file CI resolves to the latest compatible version and the missing implementations caused two `non_abstract_class_inherits_abstract_member` errors
- `EmbraceTracer` now delegates `timeProvider` to its internal `_delegate`
- `EmbraceTracerProvider` stores a `defaultTimeProvider` field and exposes the required getter/setter
- `beta.6` also added an `enum Client` to the semantics barrel, colliding with `http.Client`; fixed by hiding it from the `dartastic_opentelemetry_api` import in `http_client_test.dart`

## Test plan

- [x] `flutter analyze lib test` passes with no issues
- [x] All 243 unit tests pass (`flutter test`)
- [x] CI `flutter analyze` job passes