### PR TITLE
fix(dio): upgrade dartastic_opentelemetry_api to beta.6 and fix OTel context in tests

### DIFF
--- a/embrace/pubspec.yaml
+++ b/embrace/pubspec.yaml
@@ -13,7 +13,7 @@ flutter:
       ios:
         default_package: embrace_ios
 dependencies:
-  dartastic_opentelemetry_api: ^1.0.0-alpha
+  dartastic_opentelemetry_api: ^1.0.0-beta.6
   embrace_android: ">=4.6.0 <4.7.0"
   embrace_ios: ">=4.6.0 <4.7.0"
   embrace_platform_interface: ">=4.6.0 <4.7.0"

--- a/embrace_dio/pubspec.yaml
+++ b/embrace_dio/pubspec.yaml
@@ -16,7 +16,7 @@ dependencies:
   plugin_platform_interface: ^2.1.0
   embrace_platform_interface: ">=4.6.0 <4.7.0"
 dev_dependencies:
-  dartastic_opentelemetry_api: ^1.0.0-alpha
+  dartastic_opentelemetry_api: ^1.0.0-beta.6
   flutter_test:
     sdk: flutter
   mocktail: ^1.0.4

--- a/embrace_dio/test/embrace_dio_test.dart
+++ b/embrace_dio/test/embrace_dio_test.dart
@@ -355,7 +355,7 @@ void main() {
       final span = tracer.startSpan('test');
 
       // ignore: inference_failure_on_function_invocation
-      await dio.get('/test_url');
+      await tracer.withSpanAsync(span, () => dio.get('/test_url'));
 
       verify(
         () => platform.logNetworkRequest(
@@ -401,7 +401,7 @@ void main() {
           '00-${sc.traceId.hexString}-${sc.spanId.hexString}-$flags';
 
       // ignore: inference_failure_on_function_invocation
-      await dio.get('/test_url');
+      await tracer.withSpanAsync(span, () => dio.get('/test_url'));
 
       verify(
         () => platform.logNetworkRequest(


### PR DESCRIPTION
## Summary

- Bumps `dartastic_opentelemetry_api` from `^1.0.0-alpha` to `^1.0.0-beta.6` in both `embrace` and `embrace_dio` to align with the beta.6 APIs already used in the `embrace` package (introduced in #856b8fa).
- Fixes two OTel traceparent tests in `embrace_dio` that started a span via `startSpan` but never attached it to the current context. The interceptor's `W3cTraceContext.injectCurrentSync` only injects when a span is active in `Context.current`, so the tests now wrap `dio.get` in `tracer.withSpanAsync(span, ...)`.

## Test plan

- [x] `flutter test` in `embrace_dio` passes all 16 tests (was failing with compilation errors and 2 test failures)
- [x] `flutter test` in `embrace` continues to pass