### PR TITLE
fix(deps): pin dartastic_opentelemetry_api to exact pre-release version

### DIFF
--- a/embrace/pubspec.yaml
+++ b/embrace/pubspec.yaml
@@ -13,7 +13,7 @@ flutter:
       ios:
         default_package: embrace_ios
 dependencies:
-  dartastic_opentelemetry_api: ^1.0.0-beta.6
+  dartastic_opentelemetry_api: 1.0.0-beta.6
   embrace_android: ">=4.6.0 <4.7.0"
   embrace_ios: ">=4.6.0 <4.7.0"
   embrace_platform_interface: ">=4.6.0 <4.7.0"

--- a/embrace_dio/pubspec.yaml
+++ b/embrace_dio/pubspec.yaml
@@ -16,7 +16,7 @@ dependencies:
   plugin_platform_interface: ^2.1.0
   embrace_platform_interface: ">=4.6.0 <4.7.0"
 dev_dependencies:
-  dartastic_opentelemetry_api: ^1.0.0-beta.6
+  dartastic_opentelemetry_api: 1.0.0-beta.6
   flutter_test:
     sdk: flutter
   mocktail: ^1.0.4


### PR DESCRIPTION
## Summary
- Removes the `^` caret from `dartastic_opentelemetry_api: ^1.0.0-beta.6` in both `embrace` and `embrace_dio`
- `pub` will now always resolve to exactly `1.0.0-beta.6`, preventing CI from silently picking up newer betas with breaking API changes

## Motivation
CI was failing because a newer `dartastic_opentelemetry_api` beta was published and pub resolved to it automatically. The SDK hadn't implemented the new API yet. Pinning to an exact pre-release version gives us control over when we adopt a newer version.

## Test plan
- [ ] CI passes on this PR (verifies the pinned version resolves cleanly)
- [ ] When ready to upgrade dartastic, update both pubspec files together and verify CI