### PR TITLE
fix(ci): detect Android emulator device ID dynamically

### DIFF
--- a/.github/workflows/embrace.yaml
+++ b/.github/workflows/embrace.yaml
@@ -177,7 +177,12 @@ jobs:
             adb devices || true
             flutter --version
             flutter devices || true
-            flutter test integration_test -d emulator-5554 || { adb logcat -d > emulator_logcat.log 2>&1 || true; exit 127; }
+            DEVICE_ID=$(adb devices | grep -w device | grep emulator | head -1 | cut -f1)
+            if [ -z "$DEVICE_ID" ]; then
+              echo "No emulator device found" >&2
+              exit 1
+            fi
+            flutter test integration_test -d "$DEVICE_ID" || { adb logcat -d > emulator_logcat.log 2>&1 || true; exit 127; }
 
       - name: Archive Test Results
         if: ${{ always() }}

--- a/.github/workflows/embrace.yaml
+++ b/.github/workflows/embrace.yaml
@@ -177,12 +177,7 @@ jobs:
             adb devices || true
             flutter --version
             flutter devices || true
-            DEVICE_ID=$(adb devices | grep -w device | grep emulator | head -1 | cut -f1)
-            if [ -z "$DEVICE_ID" ]; then
-              echo "No emulator device found" >&2
-              exit 1
-            fi
-            flutter test integration_test -d "$DEVICE_ID" || { adb logcat -d > emulator_logcat.log 2>&1 || true; exit 127; }
+            DEVICE_ID=$(adb devices | grep -w device | grep emulator | head -1 | cut -f1); [ -n "$DEVICE_ID" ] || { echo "No emulator device found" >&2; exit 1; }; flutter test integration_test -d "$DEVICE_ID" || { adb logcat -d > emulator_logcat.log 2>&1 || true; exit 127; }
 
       - name: Archive Test Results
         if: ${{ always() }}


### PR DESCRIPTION
## Summary
- Replaces the hardcoded `-d emulator-5554` in the Android integration test step with a dynamic lookup
- The emulator serial is now read from `adb devices` at runtime, so the test runs correctly regardless of which port the emulator is assigned on the GitHub runner

## Motivation
GitHub-hosted runners don't guarantee the emulator connects on port 5554. When it doesn't, Flutter sees no matching device and the job fails with a connection error before any tests run.

## Test plan
- [ ] Android integration test job passes on this PR