### PR TITLE
fix(ci): pin Flutter version on iOS job to match other jobs

### DIFF
--- a/.github/workflows/embrace.yaml
+++ b/.github/workflows/embrace.yaml
@@ -199,7 +199,11 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
-      - uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2
+      - uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2 # v2.23.0
+        with:
+          flutter-version: '3.38.5'
+          channel: stable
+          cache: true
       - name: Flutter Pub Get
         run: flutter pub get
       - name: Configure App ID and API Token

--- a/.github/workflows/embrace.yaml
+++ b/.github/workflows/embrace.yaml
@@ -2,6 +2,7 @@ name: embrace
 
 env:
   ANDROID_API_LEVEL: 34
+  FLUTTER_VERSION: '3.38.5'
 
 on:
   pull_request:
@@ -47,7 +48,7 @@ jobs:
           persist-credentials: false
       - uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2 # v2.23.0
         with:
-          flutter-version: '3.38.5'
+          flutter-version: ${{ env.FLUTTER_VERSION }}
       - name: Flutter Doctor
         run: flutter doctor -v
       - name: Tests for minimum version
@@ -66,7 +67,7 @@ jobs:
       - uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2 # v2.23.0
         with:
           channel: stable
-          flutter-version: '3.38.5'
+          flutter-version: ${{ env.FLUTTER_VERSION }}
           cache: true
       - name: Flutter Doctor
         run: flutter doctor -v
@@ -118,7 +119,7 @@ jobs:
         with:
           channel: stable
           cache: true
-          flutter-version: '3.38.5'
+          flutter-version: ${{ env.FLUTTER_VERSION }}
 
       - name: Flutter pub get
         run: flutter pub get
@@ -201,7 +202,7 @@ jobs:
           persist-credentials: false
       - uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2 # v2.23.0
         with:
-          flutter-version: '3.38.5'
+          flutter-version: ${{ env.FLUTTER_VERSION }}
           channel: stable
           cache: true
       - name: Flutter Pub Get


### PR DESCRIPTION
## Summary
- Adds `flutter-version: '3.38.5'`, `channel: stable`, and `cache: true` to the `subosito/flutter-action` step in the iOS job
- Also adds the missing `# v2.23.0` comment to match the pinned commit hash used everywhere else

## Motivation
Every other job in this workflow pins Flutter to `3.38.5` on `stable`, but the iOS job had no version or channel specified — meaning it would silently use whatever the action's default resolved to. A Flutter update could break iOS integration tests while all unit test jobs stayed green.

## Test plan
- [ ] iOS integration test job passes on this PR