### PR TITLE
fix(ios): migrate example Runner app to UIScene lifecycle

### DIFF
--- a/embrace/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/embrace/example/ios/Runner.xcodeproj/project.pbxproj
@@ -15,6 +15,7 @@
 		97C147011CF9000F007C117D /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FF1CF9000F007C117D /* LaunchScreen.storyboard */; };
 		D7D908BD96C9A38F7AA909BE /* libPods-Runner.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 25DE0182FC7556D2082CB753 /* libPods-Runner.a */; };
 		E70606402C46BE9500B681B9 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = E706063F2C46BE9500B681B9 /* AppDelegate.swift */; };
+		56E0D69DD93D4786AD9E30A1 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE57787BC8154950BD955BCE /* SceneDelegate.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -49,6 +50,7 @@
 		97C147021CF9000F007C117D /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		E706063E2C46BE9500B681B9 /* Runner-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "Runner-Bridging-Header.h"; sourceTree = "<group>"; };
 		E706063F2C46BE9500B681B9 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
+		AE57787BC8154950BD955BCE /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -106,6 +108,7 @@
 			isa = PBXGroup;
 			children = (
 				E706063F2C46BE9500B681B9 /* AppDelegate.swift */,
+				AE57787BC8154950BD955BCE /* SceneDelegate.swift */,
 				97C146FA1CF9000F007C117D /* Main.storyboard */,
 				97C146FD1CF9000F007C117D /* Assets.xcassets */,
 				97C146FF1CF9000F007C117D /* LaunchScreen.storyboard */,
@@ -298,6 +301,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				E70606402C46BE9500B681B9 /* AppDelegate.swift in Sources */,
+				56E0D69DD93D4786AD9E30A1 /* SceneDelegate.swift in Sources */,
 				1498D2341E8E89220040F4C2 /* GeneratedPluginRegistrant.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/embrace/example/ios/Runner/AppDelegate.swift
+++ b/embrace/example/ios/Runner/AppDelegate.swift
@@ -22,13 +22,6 @@ import EmbraceIO
         }
     }
 
-    override func application(
-        _ application: UIApplication,
-        didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
-    ) -> Bool {
-        return super.application(application, didFinishLaunchingWithOptions: launchOptions)
-    }
-
     func didInitializeImplicitFlutterEngine(_ engineBridge: any FlutterImplicitEngineBridge) {
         GeneratedPluginRegistrant.register(with: engineBridge.pluginRegistry)
     }

--- a/embrace/example/ios/Runner/AppDelegate.swift
+++ b/embrace/example/ios/Runner/AppDelegate.swift
@@ -4,7 +4,7 @@ import Flutter
 import EmbraceIO
 
 @main
-@objc class AppDelegate: FlutterAppDelegate {
+@objc class AppDelegate: FlutterAppDelegate, FlutterImplicitEngineDelegate {
 
     override init() {
         super.init()
@@ -26,7 +26,10 @@ import EmbraceIO
         _ application: UIApplication,
         didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
     ) -> Bool {
-        GeneratedPluginRegistrant.register(with: self)
         return super.application(application, didFinishLaunchingWithOptions: launchOptions)
+    }
+
+    func didInitializeImplicitFlutterEngine(_ engineBridge: any FlutterImplicitEngineBridge) {
+        GeneratedPluginRegistrant.register(with: engineBridge.pluginRegistry)
     }
 }

--- a/embrace/example/ios/Runner/Info.plist
+++ b/embrace/example/ios/Runner/Info.plist
@@ -30,8 +30,6 @@
 	<true/>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
-	<key>UIMainStoryboardFile</key>
-	<string>Main</string>
 	<key>UISupportedInterfaceOrientations</key>
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>

--- a/embrace/example/ios/Runner/Info.plist
+++ b/embrace/example/ios/Runner/Info.plist
@@ -51,5 +51,26 @@
 	<true/>
 	<key>UIApplicationSupportsIndirectInputEvents</key>
 	<true/>
+	<key>UIApplicationSceneManifest</key>
+	<dict>
+		<key>UIApplicationSupportsMultipleScenes</key>
+		<false/>
+		<key>UISceneConfigurations</key>
+		<dict>
+			<key>UIWindowSceneSessionRoleApplication</key>
+			<array>
+				<dict>
+					<key>UISceneClassName</key>
+					<string>UIWindowScene</string>
+					<key>UISceneDelegateClassName</key>
+					<string>$(PRODUCT_MODULE_NAME).SceneDelegate</string>
+					<key>UISceneConfigurationName</key>
+					<string>flutter</string>
+					<key>UISceneStoryboardFile</key>
+					<string>Main</string>
+				</dict>
+			</array>
+		</dict>
+	</dict>
 </dict>
 </plist>

--- a/embrace/example/ios/Runner/SceneDelegate.swift
+++ b/embrace/example/ios/Runner/SceneDelegate.swift
@@ -1,0 +1,5 @@
+import Flutter
+import UIKit
+
+class SceneDelegate: FlutterSceneDelegate {
+}

--- a/embrace_dio/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/embrace_dio/example/ios/Runner.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 		331C808B294A63AB00263BE5 /* RunnerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 331C807B294A618700263BE5 /* RunnerTests.swift */; };
 		3B3967161E833CAA004F5970 /* AppFrameworkInfo.plist in Resources */ = {isa = PBXBuildFile; fileRef = 3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */; };
 		74858FAF1ED2DC5600515810 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74858FAE1ED2DC5600515810 /* AppDelegate.swift */; };
+		AC57787BC8154950BD955BCF /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD57787BC8154950BD955BD0 /* SceneDelegate.swift */; };
 		78748D4E2A52FE8B005A3040 /* Embrace-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 78748D4D2A52FE8B005A3040 /* Embrace-Info.plist */; };
 		97C146FC1CF9000F007C117D /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FA1CF9000F007C117D /* Main.storyboard */; };
 		97C146FE1CF9000F007C117D /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FD1CF9000F007C117D /* Assets.xcassets */; };
@@ -55,6 +56,7 @@
 		718D7F906296DAAE98BB26F1 /* Pods-RunnerTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.release.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.release.xcconfig"; sourceTree = "<group>"; };
 		74858FAD1ED2DC5600515810 /* Runner-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "Runner-Bridging-Header.h"; sourceTree = "<group>"; };
 		74858FAE1ED2DC5600515810 /* AppDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
+		BD57787BC8154950BD955BD0 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
 		78748D4D2A52FE8B005A3040 /* Embrace-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "Embrace-Info.plist"; sourceTree = "<group>"; };
 		7929E83E2955CA4A47190E7B /* Pods-RunnerTests.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.profile.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.profile.xcconfig"; sourceTree = "<group>"; };
 		7AFA3C8E1D35360C0083082E /* Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = Release.xcconfig; path = Flutter/Release.xcconfig; sourceTree = "<group>"; };
@@ -162,6 +164,7 @@
 				1498D2321E8E86230040F4C2 /* GeneratedPluginRegistrant.h */,
 				1498D2331E8E89220040F4C2 /* GeneratedPluginRegistrant.m */,
 				74858FAE1ED2DC5600515810 /* AppDelegate.swift */,
+				BD57787BC8154950BD955BD0 /* SceneDelegate.swift */,
 				74858FAD1ED2DC5600515810 /* Runner-Bridging-Header.h */,
 			);
 			path = Runner;
@@ -380,6 +383,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				74858FAF1ED2DC5600515810 /* AppDelegate.swift in Sources */,
+				AC57787BC8154950BD955BCF /* SceneDelegate.swift in Sources */,
 				1498D2341E8E89220040F4C2 /* GeneratedPluginRegistrant.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/embrace_dio/example/ios/Runner/AppDelegate.swift
+++ b/embrace_dio/example/ios/Runner/AppDelegate.swift
@@ -5,8 +5,8 @@ import EmbraceIO
 import EmbraceCore
 import EmbraceCrash
 
-@UIApplicationMain
-@objc class AppDelegate: FlutterAppDelegate {
+@main
+@objc class AppDelegate: FlutterAppDelegate, FlutterImplicitEngineDelegate {
 
     override init() {
         super.init()
@@ -24,11 +24,7 @@ import EmbraceCrash
         }
     }
 
-    override func application(
-        _ application: UIApplication,
-        didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
-    ) -> Bool {
-        GeneratedPluginRegistrant.register(with: self)
-        return super.application(application, didFinishLaunchingWithOptions: launchOptions)
+    func didInitializeImplicitFlutterEngine(_ engineBridge: any FlutterImplicitEngineBridge) {
+        GeneratedPluginRegistrant.register(with: engineBridge.pluginRegistry)
     }
 }

--- a/embrace_dio/example/ios/Runner/Info.plist
+++ b/embrace_dio/example/ios/Runner/Info.plist
@@ -26,8 +26,6 @@
 	<true/>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
-	<key>UIMainStoryboardFile</key>
-	<string>Main</string>
 	<key>UISupportedInterfaceOrientations</key>
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>
@@ -47,5 +45,26 @@
 	<true/>
 	<key>UIApplicationSupportsIndirectInputEvents</key>
 	<true/>
+	<key>UIApplicationSceneManifest</key>
+	<dict>
+		<key>UIApplicationSupportsMultipleScenes</key>
+		<false/>
+		<key>UISceneConfigurations</key>
+		<dict>
+			<key>UIWindowSceneSessionRoleApplication</key>
+			<array>
+				<dict>
+					<key>UISceneClassName</key>
+					<string>UIWindowScene</string>
+					<key>UISceneDelegateClassName</key>
+					<string>$(PRODUCT_MODULE_NAME).SceneDelegate</string>
+					<key>UISceneConfigurationName</key>
+					<string>flutter</string>
+					<key>UISceneStoryboardFile</key>
+					<string>Main</string>
+				</dict>
+			</array>
+		</dict>
+	</dict>
 </dict>
 </plist>

--- a/embrace_dio/example/ios/Runner/SceneDelegate.swift
+++ b/embrace_dio/example/ios/Runner/SceneDelegate.swift
@@ -1,0 +1,5 @@
+import Flutter
+import UIKit
+
+class SceneDelegate: FlutterSceneDelegate {
+}


### PR DESCRIPTION
## Summary

iOS 26 requires UIScene lifecycle support. Without it, the app crashes silently on launch and `flutter drive` hangs indefinitely in CI (no error, just no connection back from the app).

Changes to `embrace/example/ios/`:
- **SceneDelegate.swift** — new file, subclasses `FlutterSceneDelegate` which handles window/engine creation under the UIScene model
- **AppDelegate.swift** — adopts `FlutterImplicitEngineDelegate`; moves plugin registration from `application(_:didFinishLaunchingWithOptions:)` to `didInitializeImplicitFlutterEngine` (called once the Flutter engine is ready via scene setup); Embrace init in `init()` is unchanged
- **Info.plist** — adds `UIApplicationSceneManifest` so iOS uses scene lifecycle and routes to `SceneDelegate`
- **project.pbxproj** — registers `SceneDelegate.swift` in the Xcode target

## Test plan

- [ ] iOS CI job completes successfully on iOS 26.x simulator (the scenario that was hanging)
- [ ] App launches and integration tests pass