### PR TITLE
Fixed incorrect branch name in CI workflow

### DIFF
--- a/.github/workflows/embrace.yaml
+++ b/.github/workflows/embrace.yaml
@@ -15,7 +15,7 @@ on:
       - "embrace_dio/**"
   push:
     branches:
-      - master
+      - main
     paths:
       - ".github/workflows/embrace.yaml"
       - "embrace/**"


### PR DESCRIPTION
## Goal

Fixed branch name from `master` to `main`

## Testing

<!-- Describe how this change has been tested -->

## Release Notes

<!-- Notes to add in the next Release. Ignore if the changes are internal. -->

**WHAT**:<br>
**WHY**:<br>
**WHO**:<br>

