### PR TITLE
fix(ci): add per-step timeouts to iOS job

### DIFF
--- a/.github/workflows/embrace.yaml
+++ b/.github/workflows/embrace.yaml
@@ -219,6 +219,7 @@ jobs:
         run: flutter doctor -v
       - name: Create & Boot iOS Simulator (prefer iOS 17.x or 18.x)
         id: boot-sim
+        timeout-minutes: 10
         shell: bash
         run: |
           set -euo pipefail
@@ -259,6 +260,7 @@ jobs:
         env:
           STEPS_BOOT_SIM_OUTPUTS_UDID: ${{ steps.boot-sim.outputs.udid }}
       - name: Run iOS integration test
+        timeout-minutes: 25
         env:
           SIM_UDID: ${{ steps.boot-sim.outputs.udid }}
         run: |
@@ -316,6 +318,7 @@ jobs:
           retention-days: 7
       - name: Shutdown simulator
         if: always()
+        timeout-minutes: 2
         run: xcrun simctl shutdown all || true
 
 


### PR DESCRIPTION
## Summary

The `ios` job has a 45-minute job-level `timeout-minutes`. When it fires, the GitHub UI shows the *job* timed out but not which step hung — log parsing is required to identify the phase. 

This PR adds step-level caps so the step name in the Checks tab names the hang phase:

| Step | Cap | Sized from |
|---|---|---|
| `Create & Boot iOS Simulator` | 10 min | n=28 successful runs: p50 2.7m, p90 3.9m, max 4.2m (2.4× headroom) |
| `Run iOS integration test` | 25 min | n=28 successful runs: p50 6.8m, p90 11.1m, max 14.1m (1.8× headroom) |
| `Shutdown simulator` | 2 min | n=28 successful runs: max 0.4m (5× headroom) |

## Testing

<!-- Describe how this change has been tested -->

## Release Notes

<!-- Notes to add in the next Release. Ignore if the changes are internal. -->

**WHAT**:<br>
**WHY**:<br>
**WHO**:<br>

