### PR TITLE
fix(ci): surface iOS live progress and broaden simulator logs

### DIFF
--- a/.github/workflows/embrace.yaml
+++ b/.github/workflows/embrace.yaml
@@ -254,8 +254,9 @@ jobs:
           xcrun simctl list devices | grep "$UDID"
       - name: Stream Simulator Logs
         run: |
-          xcrun simctl spawn "${STEPS_BOOT_SIM_OUTPUTS_UDID}" log stream --style syslog \
-            --predicate 'process == "Runner"' > simlog.txt 2>&1 &
+          xcrun simctl spawn "${STEPS_BOOT_SIM_OUTPUTS_UDID}" log stream --style syslog --level=debug \
+            --predicate 'process IN { "Runner", "SpringBoard", "launchd_sim", "CoreSimulator", "FrontBoard" }' \
+            > simlog.txt 2>&1 &
           echo $! > log.pid
         env:
           STEPS_BOOT_SIM_OUTPUTS_UDID: ${{ steps.boot-sim.outputs.udid }}
@@ -266,7 +267,7 @@ jobs:
         run: |
           set -o pipefail
           flutter devices
-          flutter test integration_test/app_test.dart -d "$SIM_UDID" 2>&1 \
+          flutter --verbose test integration_test/app_test.dart -d "$SIM_UDID" 2>&1 \
             | tee "$RUNNER_TEMP/flutter-test.log"
       - name: Surface failure summary
         if: failure() || cancelled()


### PR DESCRIPTION
## Summary

After "Xcode build done" the `ios` job goes silent for 2-3 minutes during simulator install, app launch, and Dart VM-service attach. Any one of those phases can hang, and today you can't tell which from the log. This PR closes the
visibility gap with two changes:

- **Global `--verbose` on `flutter test`**  Each phase now emits a timestamped line: `Installing Runner.app on CI iPhone`, `Installed app on CI iPhone (15.4s)`, `Launching com.embrace.example.Runner`, `Launched ... pid=N`, `Waiting for VM Service`, `Connected to the VM Service`, `Running 1 test`. A hang in any of these phases is now visible from the log without waiting for the 25-min step timeout.
- **Broadened simulator log stream predicate**. The `Stream Simulator Logs` step used to capture `process == "Runner"` only — if Runner crashed before producing any output, the log was empty. Predicate now includes `Runner`, `SpringBoard`, `launchd_sim`, `CoreSimulator`, `FrontBoard`, with `--level=debug`. Catches launch failures, UIScene rejections, and CoreSimulator daemon issues that originate outside Runner itself.

The two layers complement: `flutter --verbose` tells you which Flutter phase is stuck; the broadened simlog tells you what the simulator/SpringBoard saw at that moment.

## Testing

<!-- Describe how this change has been tested -->

## Release Notes

<!-- Notes to add in the next Release. Ignore if the changes are internal. -->

**WHAT**:<br>
**WHY**:<br>
**WHO**:<br>

