### PR TITLE
fix(ci): bring iOS job to parity with Android practices

### DIFF
--- a/.github/workflows/embrace.yaml
+++ b/.github/workflows/embrace.yaml
@@ -193,6 +193,7 @@ jobs:
           if-no-files-found: ignore
 
   ios:
+    name: iOS (Flutter integration test, macOS-15)
     runs-on: macos-15
     timeout-minutes: 45
     defaults:
@@ -266,7 +267,8 @@ jobs:
           SIM_UDID: ${{ steps.boot-sim.outputs.udid }}
         run: |
           set -o pipefail
-          flutter devices
+          xcrun simctl bootstatus "$SIM_UDID" -b
+          flutter devices || true
           flutter --verbose test integration_test/app_test.dart -d "$SIM_UDID" 2>&1 \
             | tee "$RUNNER_TEMP/flutter-test.log"
       - name: Surface failure summary


### PR DESCRIPTION
## Summary

The sibling `android:` job has three small things the `ios:` job doesn't — none are
runner-specific. This PR adds them.

- **Give the iOS job a `name:`**. Android displays in the Checks tab as `Android (Flutter emulator, Ubuntu + KVM)`; iOS displays as `ios`. 
- **`xcrun simctl bootstatus "$SIM_UDID" -b`** before `flutter test`. Mirrors the Android job's `adb wait-for-device shell '...sys.boot_completed...'` check. Between the`Create & Boot iOS Simulator` step and `Run iOS integration test`, the simulator can die (CoreSimulator daemon crash, OOM, SpringBoard wedge). Today that produces an opaque `flutter test` failure several minutes later. `bootstatus -b` blocks briefly until the device reports booted and exits non-zero quickly if the device is gone — turning a 25-min step timeout into a seconds-long named failure.
- **`flutter devices || true`** `flutter devices` is  informational (the actual test passes `-d "$SIM_UDID"`), but today an error from that one command fails the whole step before the test gets to run.

## Testing

<!-- Describe how this change has been tested -->

## Release Notes

<!-- Notes to add in the next Release. Ignore if the changes are internal. -->

**WHAT**:<br>
**WHY**:<br>
**WHO**:<br>

