### PR TITLE
perf(ci): cache CocoaPods in iOS integration test job

### DIFF
--- a/.github/workflows/embrace.yaml
+++ b/.github/workflows/embrace.yaml
@@ -207,6 +207,15 @@ jobs:
           flutter-version: ${{ env.FLUTTER_VERSION }}
           channel: stable
           cache: true
+      - name: Cache CocoaPods
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: |
+            ~/.cocoapods
+            embrace/example/ios/Pods
+          key: pods-${{ runner.os }}-${{ hashFiles('embrace/example/ios/Podfile.lock') }}
+          restore-keys: |
+            pods-${{ runner.os }}-
       - name: Flutter Pub Get
         run: flutter pub get
       - name: Configure App ID and API Token


### PR DESCRIPTION
## Summary

- Adds a `actions/cache` step to the `ios` job in `embrace.yaml` that caches `~/.cocoapods` and `embrace/example/ios/Pods`
- Cache key is derived from `Podfile.lock`, so it only invalidates when iOS pod versions change
- A `restore-keys` fallback allows partial cache hits on key misses
- Targets the dominant cost in the iOS job: `pod install` runs fresh on every CI run inside `flutter test`, adding an estimated 2–4 minutes

## Test plan

- [x] Confirm the `ios` CI job passes on this PR
- [ ] Check the "Cache CocoaPods" step shows a cache miss on first run (expected) and a hit on a re-run

🤖 Generated with [Claude Code](https://claude.com/claude-code)