### PR TITLE
perf(ci): background iOS simulator boot to overlap with pub get

### DIFF
--- a/.github/workflows/embrace.yaml
+++ b/.github/workflows/embrace.yaml
@@ -216,18 +216,7 @@ jobs:
           key: pods-${{ runner.os }}-${{ hashFiles('embrace/example/ios/Podfile.lock') }}
           restore-keys: |
             pods-${{ runner.os }}-
-      - name: Flutter Pub Get
-        run: flutter pub get
-      - name: Configure App ID and API Token
-        run: |
-          sed -i .bak 's/YOUR_API_KEY/${{ secrets.FLUTTER_TEST_IOS_APP_ID }}/' ios/Embrace-Info.plist
-          sed -i .bak 's/YOUR_API_KEY/${{ secrets.FLUTTER_TEST_IOS_APP_ID }}/' ios/Runner.xcodeproj/project.pbxproj
-          sed -i .bak 's/YOUR_API_TOKEN/${{ secrets.FLUTTER_TEST_IOS_API_TOKEN }}/' ios/Embrace-Info.plist
-          sed -i .bak 's/YOUR_API_TOKEN/${{ secrets.FLUTTER_TEST_IOS_API_TOKEN }}/' ios/Runner.xcodeproj/project.pbxproj
-      - name: Flutter Doctor (sanity check)
-        run: flutter doctor -v
-      - name: Create & Boot iOS Simulator (prefer iOS 17.x or 18.x)
-        id: boot-sim
+      - name: Start iOS Simulator Boot
         shell: bash
         run: |
           set -euo pipefail
@@ -253,12 +242,27 @@ jobs:
 
           DEVICE_TYPE="com.apple.CoreSimulator.SimDeviceType.iPhone-15-Pro"
           UDID=$(xcrun simctl create "CI iPhone" "$DEVICE_TYPE" "$RUNTIME")
-          echo "udid=$UDID" >> "$GITHUB_OUTPUT"
-
+          echo "$UDID" > /tmp/sim_udid
           xcrun simctl boot "$UDID"
+      - name: Flutter Pub Get
+        run: flutter pub get
+      - name: Configure App ID and API Token
+        run: |
+          sed -i .bak 's/YOUR_API_KEY/${{ secrets.FLUTTER_TEST_IOS_APP_ID }}/' ios/Embrace-Info.plist
+          sed -i .bak 's/YOUR_API_KEY/${{ secrets.FLUTTER_TEST_IOS_APP_ID }}/' ios/Runner.xcodeproj/project.pbxproj
+          sed -i .bak 's/YOUR_API_TOKEN/${{ secrets.FLUTTER_TEST_IOS_API_TOKEN }}/' ios/Embrace-Info.plist
+          sed -i .bak 's/YOUR_API_TOKEN/${{ secrets.FLUTTER_TEST_IOS_API_TOKEN }}/' ios/Runner.xcodeproj/project.pbxproj
+      - name: Flutter Doctor (sanity check)
+        run: flutter doctor -v
+      - name: Wait for iOS Simulator
+        id: boot-sim
+        shell: bash
+        run: |
+          UDID=$(cat /tmp/sim_udid)
           xcrun simctl bootstatus "$UDID" -b
           xcrun simctl status_bar "$UDID" override --time 9:41 || true
           xcrun simctl list devices | grep "$UDID"
+          echo "udid=$UDID" >> "$GITHUB_OUTPUT"
       - name: Stream Simulator Logs
         run: |
           xcrun simctl spawn "${STEPS_BOOT_SIM_OUTPUTS_UDID}" log stream --style syslog \

--- a/.github/workflows/embrace.yaml
+++ b/.github/workflows/embrace.yaml
@@ -242,6 +242,7 @@ jobs:
           DEVICE_TYPE="com.apple.CoreSimulator.SimDeviceType.iPhone-15-Pro"
           UDID=$(xcrun simctl create "CI iPhone" "$DEVICE_TYPE" "$RUNTIME")
           echo "$UDID" > /tmp/sim_udid
+          # this is non-blocking
           xcrun simctl boot "$UDID"
       - name: Flutter Pub Get
         run: flutter pub get

--- a/.github/workflows/embrace.yaml
+++ b/.github/workflows/embrace.yaml
@@ -252,8 +252,6 @@ jobs:
           sed -i .bak 's/YOUR_API_KEY/${{ secrets.FLUTTER_TEST_IOS_APP_ID }}/' ios/Runner.xcodeproj/project.pbxproj
           sed -i .bak 's/YOUR_API_TOKEN/${{ secrets.FLUTTER_TEST_IOS_API_TOKEN }}/' ios/Embrace-Info.plist
           sed -i .bak 's/YOUR_API_TOKEN/${{ secrets.FLUTTER_TEST_IOS_API_TOKEN }}/' ios/Runner.xcodeproj/project.pbxproj
-      - name: Flutter Doctor (sanity check)
-        run: flutter doctor -v
       - name: Wait for iOS Simulator
         id: boot-sim
         shell: bash

--- a/.github/workflows/embrace.yaml
+++ b/.github/workflows/embrace.yaml
@@ -221,7 +221,6 @@ jobs:
         run: |
           set -euo pipefail
           xcrun simctl shutdown all || true
-          xcrun simctl erase all || true
 
           # Prefer iOS 17.*, then 18.*, avoid iOS 26+ (UIScene required, breaks flutter drive)
           RUNTIME=""


### PR DESCRIPTION
## Summary
- Splits the simulator step into **Start iOS Simulator Boot** (before pub get) and **Wait for iOS Simulator** (after configure)
- `xcrun simctl boot` is non-blocking — it enqueues the boot and returns immediately; `xcrun simctl bootstatus -b` is the actual blocking wait
- The simulator now boots in parallel with `flutter pub get`, CocoaPods restore, and app config — saving however much of the ~30–60s boot time those steps cover
- UDID is passed between steps via `/tmp/sim_udid`; downstream step references (`steps.boot-sim.outputs.udid`) are unchanged since `id: boot-sim` stays on the wait step

## Test plan
- [ ] Verify the `ios` integration test job passes end-to-end
- [ ] Confirm `Wait for iOS Simulator` completes quickly (or instantly) when pub get took long enough