### PR TITLE
fix(ci): cache CocoaPods trunk specs to survive CDN outages

### DIFF
--- a/.github/workflows/embrace.yaml
+++ b/.github/workflows/embrace.yaml
@@ -212,6 +212,11 @@ jobs:
           key: pods-${{ runner.os }}-${{ hashFiles('embrace/example/ios/Podfile.lock') }}
           restore-keys: |
             pods-${{ runner.os }}-
+      - name: Cache CocoaPods specs
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: ~/.cocoapods/repos/trunk
+          key: pods-specs-${{ runner.os }}-${{ hashFiles('embrace/example/ios/Podfile.lock') }}
       - name: Flutter Pub Get
         run: flutter pub get
       - name: Update CocoaPods specs (cache stale or miss)


### PR DESCRIPTION
## Summary

- Adds a second cache step for `~/.cocoapods/repos/trunk` alongside the existing `Pods/` cache
- Uses the same `hashFiles('Podfile.lock')` key (no `restore-keys`) so stale specs from a different lockfile are never restored
- When `Podfile.lock` is unchanged, both caches are warm and `pod install` resolves EmbraceIO specs locally — no `cdn.jsdelivr.net` requests needed

## Problem

The iOS integration test failed because `cdn.jsdelivr.net` was completely unreachable (DNS failure) on the runner. CocoaPods needs the trunk CDN to look up EmbraceIO podspecs even when `Pods/` is already cached, because `~/.cocoapods/repos/trunk` (the local spec cache) was removed from caching in #280 to prevent stale specs.

## Why this is safe

The stale-specs issue from #280 was caused by `restore-keys` falling back to specs from an older `Podfile.lock`. This new step uses **no `restore-keys`** — it only hits on an exact `Podfile.lock` match. When the lockfile changes, both caches miss together, `pod repo update` re-populates the local spec cache, and both get saved fresh.