### PR TITLE
chore: prepare 4.7.0 release

### DIFF
--- a/embrace/CHANGELOG.md
+++ b/embrace/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 4.7.0
+
+* Added `EmbraceStartupTracker` for automatic time-to-first-frame span instrumentation
+* Added time-to-interactive (TTI) span instrumentation to `EmbraceNavigationObserver`
+* Moved `EmbraceGoRouterObserver` to the standalone `embrace_go_router` package
+
 # 4.6.0
 
 * Added OpenTelemetry API compliance: `EmbraceOTelFactory`, `EmbraceTracerProvider`, `EmbraceTracer`, `EmbraceLoggerProvider`, and `EmbraceLogger` are now registered with `dartastic_opentelemetry_api` on `Embrace.start()`

--- a/embrace/pubspec.yaml
+++ b/embrace/pubspec.yaml
@@ -1,6 +1,6 @@
 name: embrace
 description: A comprehensive observability and monitoring platform for iOS and Android apps built with Flutter.
-version: 4.6.0
+version: 4.7.0
 homepage: https://embrace.io
 environment:
   sdk: ">=3.0.0 <4.0.0"
@@ -14,9 +14,9 @@ flutter:
         default_package: embrace_ios
 dependencies:
   dartastic_opentelemetry_api: 1.0.0-beta.7
-  embrace_android: ">=4.6.0 <4.7.0"
-  embrace_ios: ">=4.6.0 <4.7.0"
-  embrace_platform_interface: ">=4.6.0 <4.7.0"
+  embrace_android: ">=4.7.0 <4.8.0"
+  embrace_ios: ">=4.7.0 <4.8.0"
+  embrace_platform_interface: ">=4.7.0 <4.8.0"
   flutter:
     sdk: flutter
   http: ">=0.13.3 <2.0.0"

--- a/embrace_android/CHANGELOG.md
+++ b/embrace_android/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 4.7.0
+
+* Updated Embrace Android SDK to 8.3.1
+
 # 4.6.0
 
 * Added native handlers for `setSpanStatus`, `updateSpanName`, and `addSpanLink`

--- a/embrace_android/pubspec.yaml
+++ b/embrace_android/pubspec.yaml
@@ -1,6 +1,6 @@
 name: embrace_android
 description: Android implementation of the embrace plugin as defined by the embrace_platform_interface package.
-version: 4.6.0
+version: 4.7.0
 homepage: https://embrace.io
 environment:
   sdk: ">=3.0.0 <4.0.0"
@@ -14,7 +14,7 @@ flutter:
         pluginClass: EmbracePlugin
         dartPluginClass: EmbraceAndroid
 dependencies:
-  embrace_platform_interface: ">=4.6.0 <4.7.0"
+  embrace_platform_interface: ">=4.7.0 <4.8.0"
   flutter:
     sdk: flutter
 dev_dependencies:

--- a/embrace_dio/CHANGELOG.md
+++ b/embrace_dio/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 4.7.0
+
+* Version bump
+
 # 4.6.0
 
 * Added W3C traceparent header injection in `EmbraceInterceptor`

--- a/embrace_dio/pubspec.yaml
+++ b/embrace_dio/pubspec.yaml
@@ -1,6 +1,6 @@
 name: embrace_dio
 description: Allows automatic Dio network capture when using the the embrace plugin.
-version: 4.6.0
+version: 4.7.0
 homepage: https://embrace.io
 environment:
   sdk: ">=3.0.0 <4.0.0"
@@ -9,12 +9,12 @@ dependencies:
   build_runner: ^2.0.0
   build_version: ^2.0.0
   dio: '>=4.0.0 <6.0.0'
-  embrace: ^4.6.0
+  embrace: ^4.7.0
   flutter:
     sdk: flutter
   platform: ^3.1.0
   plugin_platform_interface: ^2.1.0
-  embrace_platform_interface: ">=4.6.0 <4.7.0"
+  embrace_platform_interface: ">=4.7.0 <4.8.0"
 dev_dependencies:
   dartastic_opentelemetry_api: 1.0.0-beta.7
   flutter_test:

--- a/embrace_go_router/CHANGELOG.md
+++ b/embrace_go_router/CHANGELOG.md
@@ -1,3 +1,3 @@
-# 1.0.0
+# 4.7.0
 
-* Initial release of `embrace_go_router`. Provides `EmbraceGoRouterObserver` for automatic navigation tracking in apps using go_router.
+* Initial release of `embrace_go_router`. Provides `EmbraceGoRouterObserver` for automatic navigation tracking and time-to-interactive (TTI) span instrumentation in apps using go_router.

--- a/embrace_go_router/pubspec.yaml
+++ b/embrace_go_router/pubspec.yaml
@@ -1,17 +1,17 @@
 name: embrace_go_router
 description: Provides go_router navigation tracking for the Embrace SDK.
-version: 1.0.0
+version: 4.7.0
 homepage: https://embrace.io
 environment:
   sdk: ">=3.0.0 <4.0.0"
   flutter: ">=3.10.0"
 dependencies:
-  embrace: ^4.6.0
+  embrace: ^4.7.0
   flutter:
     sdk: flutter
   go_router: ">=6.0.0 <16.0.0"
 dev_dependencies:
-  embrace_platform_interface: ">=4.6.0 <4.7.0"
+  embrace_platform_interface: ">=4.7.0 <4.8.0"
   flutter_test:
     sdk: flutter
   mocktail: ">=0.3.0 <2.0.0"

--- a/embrace_ios/CHANGELOG.md
+++ b/embrace_ios/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 4.7.0
+
+* Updated Embrace iOS SDK to 6.20.0
+
 # 4.6.0
 
 * Added native handlers for `setSpanStatus`, `updateSpanName`, and `addSpanLink`

--- a/embrace_ios/pubspec.yaml
+++ b/embrace_ios/pubspec.yaml
@@ -1,6 +1,6 @@
 name: embrace_ios
 description: iOS implementation of the embrace plugin as defined by the embrace_platform_interface package.
-version: 4.6.0
+version: 4.7.0
 homepage: https://embrace.io
 environment:
   sdk: ">=3.0.0 <4.0.0"
@@ -13,7 +13,7 @@ flutter:
         pluginClass: EmbracePlugin
         dartPluginClass: EmbraceIOS
 dependencies:
-  embrace_platform_interface: ">=4.6.0 <4.7.0"
+  embrace_platform_interface: ">=4.7.0 <4.8.0"
   flutter:
     sdk: flutter
 dev_dependencies:

--- a/embrace_platform_interface/CHANGELOG.md
+++ b/embrace_platform_interface/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 4.7.0
+
+* Fixed null returns from span method channel calls
+
 # 4.6.0
 
 * Added `EmbraceOTelSpan` (implements `APISpan`) with span lifecycle methods

--- a/embrace_platform_interface/lib/src/version.dart
+++ b/embrace_platform_interface/lib/src/version.dart
@@ -1,2 +1,2 @@
 // Generated code. Do not modify.
-const packageVersion = '4.6.0';
+const packageVersion = '4.7.0';

--- a/embrace_platform_interface/pubspec.yaml
+++ b/embrace_platform_interface/pubspec.yaml
@@ -1,6 +1,6 @@
 name: embrace_platform_interface
 description: A common platform interface for the Embrace plugin that enables platform-specific implementations.
-version: 4.6.0
+version: 4.7.0
 homepage: https://embrace.io
 environment:
   sdk: ">=3.0.0 <4.0.0"

--- a/verify_versions.sh
+++ b/verify_versions.sh
@@ -55,6 +55,7 @@ declare -r EMBRACE_PLATFORM_INTERFACE_PUBSPEC_PATH='embrace_platform_interface/p
 declare -r EMBRACE_ANDROID_PUBSPEC_PATH='embrace_android/pubspec.yaml'
 declare -r EMBRACE_IOS_PUBSPEC_PATH='embrace_ios/pubspec.yaml'
 declare -r EMBRACE_DIO_PUBSPEC_PATH='embrace_dio/pubspec.yaml'
+declare -r EMBRACE_GO_ROUTER_PUBSPEC_PATH='embrace_go_router/pubspec.yaml'
 
 declare -r EMBRACE_DEPENDENCY_NAME='.dependencies.embrace'
 declare -r PLATFORM_INTERFACE_DEPENDENCY_NAME='.dependencies.embrace_platform_interface'
@@ -62,11 +63,12 @@ declare -r ANDROID_DEPENDENCY_NAME='.dependencies.embrace_android'
 declare -r IOS_DEPENDENCY_NAME='.dependencies.embrace_ios'
 declare -r DIO_DEPENDENCY_NAME='.dependencies.embrace_dio'
 
-# Verify versions of all 5 packages are the same
+# Verify versions of all 6 packages are the same
 verify_versions_match $EMBRACE_PUBSPEC_PATH $EMBRACE_PLATFORM_INTERFACE_PUBSPEC_PATH
 verify_versions_match $EMBRACE_PUBSPEC_PATH $EMBRACE_ANDROID_PUBSPEC_PATH
 verify_versions_match $EMBRACE_PUBSPEC_PATH $EMBRACE_IOS_PUBSPEC_PATH
 verify_versions_match $EMBRACE_PUBSPEC_PATH $EMBRACE_DIO_PUBSPEC_PATH
+verify_versions_match $EMBRACE_PUBSPEC_PATH $EMBRACE_GO_ROUTER_PUBSPEC_PATH
 
 # Verify dependencies match current package versions
 verify_dependency $EMBRACE_PUBSPEC_PATH $PLATFORM_INTERFACE_DEPENDENCY_NAME $EMBRACE_PLATFORM_INTERFACE_PUBSPEC_PATH
@@ -74,6 +76,8 @@ verify_dependency $EMBRACE_PUBSPEC_PATH $ANDROID_DEPENDENCY_NAME $EMBRACE_ANDROI
 verify_dependency $EMBRACE_PUBSPEC_PATH $IOS_DEPENDENCY_NAME $EMBRACE_IOS_PUBSPEC_PATH
 verify_dependency $EMBRACE_ANDROID_PUBSPEC_PATH $PLATFORM_INTERFACE_DEPENDENCY_NAME $EMBRACE_PLATFORM_INTERFACE_PUBSPEC_PATH
 verify_dependency $EMBRACE_IOS_PUBSPEC_PATH $PLATFORM_INTERFACE_DEPENDENCY_NAME $EMBRACE_PLATFORM_INTERFACE_PUBSPEC_PATH
+verify_dependency $EMBRACE_GO_ROUTER_PUBSPEC_PATH $EMBRACE_DEPENDENCY_NAME $EMBRACE_PUBSPEC_PATH
+verify_dependency $EMBRACE_GO_ROUTER_PUBSPEC_PATH '.dev_dependencies.embrace_platform_interface' $EMBRACE_PLATFORM_INTERFACE_PUBSPEC_PATH
 
 # Verify version in generated script is the same
 declare -r GENERATED_VERSION_SCRIPT_PATH=embrace_platform_interface/lib/src/version.dart


### PR DESCRIPTION
## Summary

- Bumped all 6 packages to 4.7.0 (`embrace`, `embrace_platform_interface`, `embrace_android`, `embrace_ios`, `embrace_dio`, `embrace_go_router`)
- Updated all inter-package dependency ranges
- Updated `version.dart` to 4.7.0
- Added `embrace_go_router` to `verify_versions.sh`

## Changelog highlights

- Added `EmbraceStartupTracker` for automatic time-to-first-frame span instrumentation
- Added time-to-interactive (TTI) span instrumentation to `EmbraceNavigationObserver`
- Initial release of `embrace_go_router` with `EmbraceGoRouterObserver` (navigation tracking + TTI spans)
- Updated Embrace Android SDK to 8.3.1
- Updated Embrace iOS SDK to 6.20.0
- Fixed null returns from span method channel calls

## Test plan

- [ ] Build to device on iOS
- [ ] Run in emulator on Android