### PR TITLE
Include startTimeMs when starting TTI span

### DIFF
--- a/embrace/lib/src/navigation_observer.dart
+++ b/embrace/lib/src/navigation_observer.dart
@@ -54,6 +54,7 @@ class EmbraceNavigationObserver extends RouteObserver<ModalRoute<dynamic>> {
   }
 
   void _startTtiSpan(String routeName) {
+    final startTimeMs = DateTime.now().millisecondsSinceEpoch;
     int? endTimeMs;
     EmbraceSpan? pendingSpan;
 
@@ -67,7 +68,12 @@ class EmbraceNavigationObserver extends RouteObserver<ModalRoute<dynamic>> {
       }
     }
 
-    Embrace.instance.startSpan('emb-flutter-time-to-interactive').then(
+    Embrace.instance
+        .startSpan(
+          'emb-flutter-time-to-interactive',
+          startTimeMs: startTimeMs,
+        )
+        .then(
       (span) {
         pendingSpan = span;
         tryStop();

--- a/embrace/lib/src/navigation_observer.dart
+++ b/embrace/lib/src/navigation_observer.dart
@@ -70,9 +70,9 @@ class EmbraceNavigationObserver extends RouteObserver<ModalRoute<dynamic>> {
 
     Embrace.instance
         .startSpan(
-          'emb-flutter-time-to-interactive',
-          startTimeMs: startTimeMs,
-        )
+      'emb-flutter-time-to-interactive',
+      startTimeMs: startTimeMs,
+    )
         .then(
       (span) {
         pendingSpan = span;

--- a/embrace/test/src/navigation_observer_test.dart
+++ b/embrace/test/src/navigation_observer_test.dart
@@ -144,8 +144,12 @@ void main() {
         debugEmbraceOverride = mockEmbrace;
         when(() => mockEmbrace.startView(any())).thenAnswer((_) {});
         when(() => mockEmbrace.endView(any())).thenAnswer((_) {});
-        when(() => mockEmbrace.startSpan('emb-flutter-time-to-interactive'))
-            .thenAnswer((_) => Future.value(mockSpan));
+        when(
+          () => mockEmbrace.startSpan(
+            'emb-flutter-time-to-interactive',
+            startTimeMs: any(named: 'startTimeMs'),
+          ),
+        ).thenAnswer((_) => Future.value(mockSpan));
         when(() => mockSpan.addAttribute(any(), any()))
             .thenAnswer((_) async => true);
         when(() => mockSpan.stop(endTimeMs: any(named: 'endTimeMs')))
@@ -163,7 +167,10 @@ void main() {
         await tester.pump();
 
         verify(
-          () => mockEmbrace.startSpan('emb-flutter-time-to-interactive'),
+          () => mockEmbrace.startSpan(
+            'emb-flutter-time-to-interactive',
+            startTimeMs: any(named: 'startTimeMs'),
+          ),
         ).called(1);
         verify(() => mockSpan.addAttribute('route', 'route')).called(1);
         verify(
@@ -199,7 +206,10 @@ void main() {
         await tester.pump();
 
         verify(
-          () => mockEmbrace.startSpan('emb-flutter-time-to-interactive'),
+          () => mockEmbrace.startSpan(
+            'emb-flutter-time-to-interactive',
+            startTimeMs: any(named: 'startTimeMs'),
+          ),
         ).called(1);
         verify(() => mockSpan.addAttribute('route', 'route')).called(1);
         verify(


### PR DESCRIPTION
Capture the current timestamp and pass it as startTimeMs to Embrace.startSpan so the time-to-interactive span uses an explicit start time. Update tests to expect the startSpan call with the named startTimeMs argument and adjust mocks accordingly.

This fixes an issue where spans can be negative because of the async code.