### PR TITLE
rename flutter span names to emb-{name}-flutter format

### DIFF
--- a/embrace/lib/src/embrace_startup_tracker.dart
+++ b/embrace/lib/src/embrace_startup_tracker.dart
@@ -20,7 +20,7 @@ class EmbraceStartupTracker {
   }
 
   /// Waits for the first rasterized frame and records an
-  /// `emb-flutter-time-to-first-frame` span covering Dart init → pixels on
+  /// `emb-time-to-first-frame-flutter` span covering Dart init → pixels on
   /// screen.
   static Future<void> recordFirstFrame() async {
     final stopwatch = _stopwatch;
@@ -30,7 +30,7 @@ class EmbraceStartupTracker {
     await WidgetsBinding.instance.waitUntilFirstFrameRasterized;
     final elapsedMs = stopwatch.elapsedMilliseconds;
     await EmbracePlatform.instance.recordCompletedSpan(
-      'emb-flutter-time-to-first-frame',
+      'emb-time-to-first-frame-flutter',
       startEpochMs,
       startEpochMs + elapsedMs,
     );

--- a/embrace/lib/src/navigation_observer.dart
+++ b/embrace/lib/src/navigation_observer.dart
@@ -70,7 +70,7 @@ class EmbraceNavigationObserver extends RouteObserver<ModalRoute<dynamic>> {
 
     Embrace.instance
         .startSpan(
-      'emb-flutter-time-to-interactive',
+      'emb-time-to-interactive-flutter',
       startTimeMs: startTimeMs,
     )
         .then(

--- a/embrace/test/src/navigation_observer_test.dart
+++ b/embrace/test/src/navigation_observer_test.dart
@@ -146,7 +146,7 @@ void main() {
         when(() => mockEmbrace.endView(any())).thenAnswer((_) {});
         when(
           () => mockEmbrace.startSpan(
-            'emb-flutter-time-to-interactive',
+            'emb-time-to-interactive-flutter',
             startTimeMs: any(named: 'startTimeMs'),
           ),
         ).thenAnswer((_) => Future.value(mockSpan));
@@ -168,7 +168,7 @@ void main() {
 
         verify(
           () => mockEmbrace.startSpan(
-            'emb-flutter-time-to-interactive',
+            'emb-time-to-interactive-flutter',
             startTimeMs: any(named: 'startTimeMs'),
           ),
         ).called(1);
@@ -207,7 +207,7 @@ void main() {
 
         verify(
           () => mockEmbrace.startSpan(
-            'emb-flutter-time-to-interactive',
+            'emb-time-to-interactive-flutter',
             startTimeMs: any(named: 'startTimeMs'),
           ),
         ).called(1);

--- a/embrace_go_router/lib/src/go_router_observer.dart
+++ b/embrace_go_router/lib/src/go_router_observer.dart
@@ -170,7 +170,7 @@ class EmbraceGoRouterObserver extends NavigatorObserver {
       }
     }
 
-    Embrace.instance.startSpan('emb-flutter-time-to-interactive').then(
+    Embrace.instance.startSpan('emb-time-to-interactive-flutter').then(
       (span) {
         pendingSpan = span;
         tryStop();

--- a/embrace_go_router/test/go_router_observer_test.dart
+++ b/embrace_go_router/test/go_router_observer_test.dart
@@ -123,7 +123,7 @@ void main() {
         debugEmbraceOverride = mockEmbrace;
         when(() => mockEmbrace.startView(any())).thenAnswer((_) {});
         when(() => mockEmbrace.endView(any())).thenAnswer((_) {});
-        when(() => mockEmbrace.startSpan('emb-flutter-time-to-interactive'))
+        when(() => mockEmbrace.startSpan('emb-time-to-interactive-flutter'))
             .thenAnswer((_) => Future.value(mockSpan));
         when(() => mockSpan.addAttribute(any(), any()))
             .thenAnswer((_) async => true);
@@ -142,7 +142,7 @@ void main() {
         await tester.pump();
 
         verify(
-          () => mockEmbrace.startSpan('emb-flutter-time-to-interactive'),
+          () => mockEmbrace.startSpan('emb-time-to-interactive-flutter'),
         ).called(1);
         verify(() => mockSpan.addAttribute('route', '/route')).called(1);
         verify(
@@ -178,7 +178,7 @@ void main() {
         await tester.pump();
 
         verify(
-          () => mockEmbrace.startSpan('emb-flutter-time-to-interactive'),
+          () => mockEmbrace.startSpan('emb-time-to-interactive-flutter'),
         ).called(1);
         verify(() => mockSpan.addAttribute('route', '/new')).called(1);
         verify(
@@ -226,7 +226,7 @@ void main() {
         () => mockEmbrace.startSpan('emb-state-screen-flutter-automatic'),
       ).thenAnswer((_) => Future.value(mockStateSpan));
       when(
-        () => mockEmbrace.startSpan('emb-flutter-time-to-interactive'),
+        () => mockEmbrace.startSpan('emb-time-to-interactive-flutter'),
       ).thenAnswer((_) => Future.value(mockTtiSpan));
       when(() => mockStateSpan.addAttribute(any(), any()))
           .thenAnswer((_) async => true);
@@ -391,7 +391,7 @@ void main() {
         await tester.pump();
 
         verify(
-          () => mockEmbrace.startSpan('emb-flutter-time-to-interactive'),
+          () => mockEmbrace.startSpan('emb-time-to-interactive-flutter'),
         ).called(1);
         verify(() => mockTtiSpan.addAttribute('route', '/')).called(1);
         verify(
@@ -410,7 +410,7 @@ void main() {
         await tester.pump();
 
         verify(
-          () => mockEmbrace.startSpan('emb-flutter-time-to-interactive'),
+          () => mockEmbrace.startSpan('emb-time-to-interactive-flutter'),
         ).called(2);
         verify(() => mockTtiSpan.addAttribute('route', '/home')).called(1);
       });


### PR DESCRIPTION
Renaming the `time-to-interactive` and `time-to-first-frame` spans to line with our naming conventions of having the span end in the platform the span is coming from.

