### PR TITLE
fix(ci): migrate ios job to macos-26 runner

### DIFF
--- a/.github/workflows/embrace.yaml
+++ b/.github/workflows/embrace.yaml
@@ -189,8 +189,8 @@ jobs:
           if-no-files-found: ignore
 
   ios:
-    name: iOS (Flutter integration test, macOS-15)
-    runs-on: macos-15
+    name: iOS (Flutter integration test, macOS-26)
+    runs-on: macos-26
     timeout-minutes: 45
     defaults:
       run:
@@ -228,7 +228,7 @@ jobs:
           sed -i .bak 's/YOUR_API_KEY/${{ secrets.FLUTTER_TEST_IOS_APP_ID }}/' ios/Runner.xcodeproj/project.pbxproj
           sed -i .bak 's/YOUR_API_TOKEN/${{ secrets.FLUTTER_TEST_IOS_API_TOKEN }}/' ios/Embrace-Info.plist
           sed -i .bak 's/YOUR_API_TOKEN/${{ secrets.FLUTTER_TEST_IOS_API_TOKEN }}/' ios/Runner.xcodeproj/project.pbxproj
-      - name: Create & Boot iOS Simulator (prefer iOS 17.x or 18.x)
+      - name: Create & Boot iOS Simulator (latest available runtime)
         id: boot-sim
         timeout-minutes: 10
         shell: bash
@@ -237,19 +237,17 @@ jobs:
           xcrun simctl shutdown all || true
           xcrun simctl erase all || true
 
-          # Prefer iOS 17.*, then 18.*, avoid iOS 26+ (UIScene required, breaks flutter drive)
-          RUNTIME=""
-          for PREFIX in "17." "18."; do
-            RUNTIME=$(xcrun simctl list runtimes -j \
-              | jq -r --arg p "$PREFIX" '.runtimes[] | select(.platform=="iOS" and .isAvailable==true and (.version|startswith($p))) | .identifier' \
-              | sort -V | tail -n1)
-            [[ -n "${RUNTIME:-}" ]] && break
-          done
+          # macos-26 only ships iOS 26.x runtimes. The Runner app was migrated to the
+          # UIScene lifecycle (SceneDelegate.swift) that iOS 26 requires, so just take
+          # the newest available runtime instead of pinning to older versions.
+          RUNTIME=$(xcrun simctl list runtimes -j \
+            | jq -r '.runtimes[] | select(.platform=="iOS" and .isAvailable==true) | .identifier' \
+            | sort -V | tail -n1)
           if [[ -z "${RUNTIME:-}" ]]; then
             selected=$(xcodebuild -version 2>/dev/null | tr '\n' ' ')
-            echo "::error title=No iOS runtime::no iOS 17.x or 18.x runtime found; ${selected}has no matching simulator runtime baked in"
+            echo "::error title=No iOS runtime::no available iOS runtime found; ${selected}has no simulator runtime baked in"
             {
-              echo "### ❌ No iOS 17.x/18.x simulator runtime available"
+              echo "### ❌ No iOS simulator runtime available"
               echo ""
               echo "Selected Xcode: \`${selected}\`"
               echo ""
@@ -271,7 +269,7 @@ jobs:
           echo "Selected runtime: $RUNTIME"
           echo "runtime=$RUNTIME" >> "$GITHUB_OUTPUT"
 
-          DEVICE_TYPE="com.apple.CoreSimulator.SimDeviceType.iPhone-15-Pro"
+          DEVICE_TYPE="com.apple.CoreSimulator.SimDeviceType.iPhone-17"
           UDID=$(xcrun simctl create "CI iPhone" "$DEVICE_TYPE" "$RUNTIME")
           echo "udid=$UDID" >> "$GITHUB_OUTPUT"
 


### PR DESCRIPTION
## What

Migrates the `ios` job in `embrace.yaml` from `macos-15` to the explicit `macos-26` runner image, mirroring [embrace-apple-sdk#679](https://github.com/embrace-io/embrace-apple-sdk/pull/679).

- `runs-on: macos-15` → `macos-26`
- Simulator selection simplified: `macos-26` only ships iOS 26.x runtimes (no 17.x/18.x), so instead of the old version-prefix allowlist it now just takes the newest available runtime
- Simulator device type bumped from `iPhone-15-Pro` → `iPhone-17` (15 Pro isn't a supported device type on iOS 26.x runtimes)
- Removed the stale "avoid iOS 26+" guard/comment — that restriction was added in `d8a9d19` because iOS 26 simulators require UIScene lifecycle support, but the Runner app was already migrated to support it the same day in `273e07e` (`SceneDelegate.swift` + `UIApplicationSceneManifest`); the CI guard just never got revisited

No explicit Xcode pin needed (unlike the Apple SDK repo) since this job never pinned one — it picks up `macos-26`'s default Xcode automatically.

## Why

`macos-15` isn't urgently deprecated for us (we already pin it explicitly, not the floating `macos-latest` that GitHub is repointing to `macos-26` in June 2026), but getting ahead of the runner migration now avoids scrambling later, and unblocks on the UIScene fix that already landed.

## Validation

Unverified on a live `macos-26` runner — this PR's own CI run against the `ios` job is the real test. Watch for:
- `jq`/runtime-selection step resolving to a valid iOS 26.x runtime
- `iPhone-17` device type creating successfully
- `flutter drive` completing against the iOS 26.x simulator without the UIScene-related hang previously seen