### PR TITLE
Replace startView/endView with OTel route transition spans in EmbraceNavigationObserver

### DIFF
--- a/embrace/lib/src/navigation_observer.dart
+++ b/embrace/lib/src/navigation_observer.dart
@@ -9,9 +9,9 @@ typedef EmbraceRouteSettingsExtractor = RouteSettings? Function(
 );
 
 /// {@template embrace_navigation_observer}
-/// A [NavigatorObserver] that automatically tracks app navigation
-/// This class registers in Embrace when a view starts or stops by listening
-/// when a route is pushed or popped.
+/// A [NavigatorObserver] that automatically tracks app navigation.
+/// Records an OTel span for each named route transition, from push/replace
+/// until the transition animation completes.
 ///
 /// [EmbraceNavigationObserver] should be added to the [navigationObserver](https://api.flutter.dev/flutter/material/MaterialApp/navigatorObservers.html)
 /// of [MaterialApp] or your main [Navigator].
@@ -88,47 +88,66 @@ class EmbraceNavigationObserver extends RouteObserver<ModalRoute<dynamic>> {
     SchedulerBinding.instance.scheduleFrame();
   }
 
-  void _updateView(Route<dynamic>? newRoute, Route<dynamic>? oldRoute) {
-    if (oldRoute != null) {
-      final settings = routeSettingsExtractor?.call(oldRoute);
-      final name = settings?.name;
-      if (name != null) {
-        Embrace.instance.endView(name);
+  void _startTransitionSpan(Route<dynamic> route, String routeName) {
+    final startTimeMs = DateTime.now().millisecondsSinceEpoch;
+    final animation = route is TransitionRoute ? route.animation : null;
+    EmbraceSpan? pendingSpan;
+    var stopped = false;
+
+    void stopSpan() {
+      if (stopped) return;
+      stopped = true;
+      pendingSpan?.stop(endTimeMs: DateTime.now().millisecondsSinceEpoch);
+    }
+
+    Embrace.instance.startSpan(routeName, startTimeMs: startTimeMs).then(
+      (span) {
+        if (span == null) return;
+        span.addAttribute('emb.type', 'view');
+        pendingSpan = span;
+        if (stopped) {
+          span.stop(endTimeMs: DateTime.now().millisecondsSinceEpoch);
+        }
+      },
+      onError: (_, __) {},
+    );
+
+    if (animation == null ||
+        animation.status == AnimationStatus.completed ||
+        animation.status == AnimationStatus.dismissed) {
+      stopSpan();
+      return;
+    }
+
+    void listener(AnimationStatus status) {
+      if (status == AnimationStatus.completed ||
+          status == AnimationStatus.dismissed) {
+        animation.removeStatusListener(listener);
+        stopSpan();
       }
     }
-    if (newRoute != null) {
-      final settings = routeSettingsExtractor?.call(newRoute);
-      final name = settings?.name;
-      if (name != null) {
-        Embrace.instance.startView(name);
-      }
-    }
+
+    animation.addStatusListener(listener);
   }
 
   @override
   void didPush(Route<dynamic> route, Route<dynamic>? previousRoute) {
     super.didPush(route, previousRoute);
-    _updateView(route, previousRoute);
     final routeName = routeSettingsExtractor?.call(route)?.name;
     if (routeName != null) {
       _startTtiSpan(routeName);
+      _startTransitionSpan(route, routeName);
     }
   }
 
   @override
   void didReplace({Route<dynamic>? newRoute, Route<dynamic>? oldRoute}) {
     super.didReplace(newRoute: newRoute, oldRoute: oldRoute);
-    _updateView(newRoute, oldRoute);
-    final routeName =
-        newRoute != null ? routeSettingsExtractor?.call(newRoute)?.name : null;
+    if (newRoute == null) return;
+    final routeName = routeSettingsExtractor?.call(newRoute)?.name;
     if (routeName != null) {
       _startTtiSpan(routeName);
+      _startTransitionSpan(newRoute, routeName);
     }
-  }
-
-  @override
-  void didPop(Route<dynamic> route, Route<dynamic>? previousRoute) {
-    super.didPop(route, previousRoute);
-    _updateView(previousRoute, route);
   }
 }

--- a/embrace/test/src/navigation_observer_test.dart
+++ b/embrace/test/src/navigation_observer_test.dart
@@ -1,5 +1,4 @@
 import 'package:embrace/embrace.dart';
-import 'package:embrace_platform_interface/embrace_platform_interface.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
@@ -14,121 +13,6 @@ void main() {
   });
 
   group('EmbraceNavigationObserver', () {
-    group('view tracking', () {
-      late MockEmbracePlatform platform;
-
-      setUp(() {
-        platform = MockEmbracePlatform();
-        EmbracePlatform.instance = platform;
-      });
-
-      group('didPush', () {
-        test('ends previous view', () {
-          final route = FakeRoute(const RouteSettings(name: 'route'));
-          final previousRoute = FakeRoute(
-            const RouteSettings(name: 'previousRoute'),
-          );
-          observer.didPush(route, previousRoute);
-
-          verify(() => platform.endView('previousRoute')).called(1);
-        });
-
-        test('starts new view', () {
-          final route = FakeRoute(const RouteSettings(name: 'route'));
-          final previousRoute = FakeRoute(
-            const RouteSettings(name: 'previousRoute'),
-          );
-          observer.didPush(route, previousRoute);
-
-          verify(() => platform.startView('route')).called(1);
-        });
-
-        test('does not end view if previousRoute is null', () {
-          final route = FakeRoute(const RouteSettings(name: 'route'));
-          observer.didPush(route, null);
-          verifyNever(() => platform.endView(any()));
-        });
-
-        test('can use custom name for starting view via routeSettingsExtractor',
-            () {
-          final observer = EmbraceNavigationObserver(
-            routeSettingsExtractor: (route) =>
-                RouteSettings(name: route.settings.name?.toUpperCase()),
-          );
-          final route = FakeRoute(const RouteSettings(name: 'route'));
-          observer.didPush(route, null);
-          verify(() => platform.startView('ROUTE')).called(1);
-        });
-
-        test('can use custom name for ending view via routeSettingsExtractor',
-            () {
-          final observer = EmbraceNavigationObserver(
-            routeSettingsExtractor: (route) =>
-                RouteSettings(name: route.settings.name?.toUpperCase()),
-          );
-          final route = FakeRoute(const RouteSettings(name: 'route'));
-          final previousRoute = FakeRoute(
-            const RouteSettings(name: 'previousRoute'),
-          );
-          observer.didPush(route, previousRoute);
-          verify(() => platform.endView('PREVIOUSROUTE')).called(1);
-        });
-      });
-
-      group('didPop', () {
-        test('starts back previous view', () {
-          final route = FakeRoute(const RouteSettings(name: 'route'));
-          final previousRoute = FakeRoute(
-            const RouteSettings(name: 'previousRoute'),
-          );
-          observer.didPop(route, previousRoute);
-
-          verify(() => platform.startView('previousRoute')).called(1);
-        });
-
-        test('ends popped view', () {
-          final route = FakeRoute(const RouteSettings(name: 'route'));
-          final previousRoute = FakeRoute(
-            const RouteSettings(name: 'previousRoute'),
-          );
-          observer.didPop(route, previousRoute);
-
-          verify(() => platform.endView('route')).called(1);
-        });
-
-        test('does not start view if previousRoute is null', () {
-          final route = FakeRoute(const RouteSettings(name: 'route'));
-          observer.didPop(route, null);
-          verifyNever(() => platform.startView(any()));
-        });
-
-        test('can use custom name for ending view via routeSettingsExtractor',
-            () {
-          final observer = EmbraceNavigationObserver(
-            routeSettingsExtractor: (route) =>
-                RouteSettings(name: route.settings.name?.toUpperCase()),
-          );
-          final route = FakeRoute(const RouteSettings(name: 'route'));
-          observer.didPop(route, null);
-          verify(() => platform.endView('ROUTE')).called(1);
-        });
-
-        test('can use custom name for starting view via routeSettingsExtractor',
-            () {
-          final observer = EmbraceNavigationObserver(
-            routeSettingsExtractor: (route) =>
-                RouteSettings(name: route.settings.name?.toUpperCase()),
-          );
-          final route = FakeRoute(const RouteSettings(name: 'route'));
-          final previousRoute = FakeRoute(
-            const RouteSettings(name: 'previousRoute'),
-          );
-          observer.didPop(route, previousRoute);
-          verify(() => platform.startView('PREVIOUSROUTE')).called(1);
-        });
-      });
-    });
-
     group('TTI spans', () {
       late MockEmbrace mockEmbrace;
       late MockEmbraceSpan mockSpan;
@@ -142,8 +26,15 @@ void main() {
         mockSpan = MockEmbraceSpan();
         // ignore: invalid_use_of_visible_for_testing_member
         debugEmbraceOverride = mockEmbrace;
-        when(() => mockEmbrace.startView(any())).thenAnswer((_) {});
-        when(() => mockEmbrace.endView(any())).thenAnswer((_) {});
+        // Route transition spans are started alongside TTI spans on every
+        // push/replace; stub them to a no-op span so they don't interfere
+        // with the TTI-specific assertions below.
+        when(
+          () => mockEmbrace.startSpan(
+            any(),
+            startTimeMs: any(named: 'startTimeMs'),
+          ),
+        ).thenAnswer((_) => Future.value());
         when(
           () => mockEmbrace.startSpan(
             'emb-time-to-interactive-flutter',
@@ -234,6 +125,206 @@ void main() {
         await tester.pump();
 
         verifyNever(() => mockEmbrace.startSpan(any()));
+      });
+    });
+
+    group('route transition spans', () {
+      late MockEmbrace mockEmbrace;
+      late MockEmbraceSpan mockTransitionSpan;
+      late MockEmbraceSpan mockTtiSpan;
+
+      setUpAll(() {
+        registerFallbackValue('');
+      });
+
+      setUp(() {
+        mockEmbrace = MockEmbrace();
+        mockTransitionSpan = MockEmbraceSpan();
+        mockTtiSpan = MockEmbraceSpan();
+        // ignore: invalid_use_of_visible_for_testing_member
+        debugEmbraceOverride = mockEmbrace;
+        when(
+          () => mockEmbrace.startSpan(
+            'emb-time-to-interactive-flutter',
+            startTimeMs: any(named: 'startTimeMs'),
+          ),
+        ).thenAnswer((_) => Future.value(mockTtiSpan));
+        for (final name in ['route', 'ROUTE']) {
+          when(
+            () => mockEmbrace.startSpan(
+              name,
+              startTimeMs: any(named: 'startTimeMs'),
+            ),
+          ).thenAnswer((_) => Future.value(mockTransitionSpan));
+        }
+        when(() => mockTransitionSpan.addAttribute(any(), any()))
+            .thenAnswer((_) async => true);
+        when(() => mockTransitionSpan.stop(endTimeMs: any(named: 'endTimeMs')))
+            .thenAnswer((_) async => true);
+        when(() => mockTtiSpan.addAttribute(any(), any()))
+            .thenAnswer((_) async => true);
+        when(() => mockTtiSpan.stop(endTimeMs: any(named: 'endTimeMs')))
+            .thenAnswer((_) async => true);
+      });
+
+      tearDown(() {
+        // ignore: invalid_use_of_visible_for_testing_member
+        debugEmbraceOverride = null;
+      });
+
+      testWidgets('starts a span named after the route on push',
+          (tester) async {
+        final route = FakeRoute(const RouteSettings(name: 'route'));
+        observer.didPush(route, null);
+        await tester.pump();
+
+        verify(
+          () => mockEmbrace.startSpan(
+            'route',
+            startTimeMs: any(named: 'startTimeMs'),
+          ),
+        ).called(1);
+        verify(() => mockTransitionSpan.addAttribute('emb.type', 'view'))
+            .called(1);
+      });
+
+      testWidgets('ends the span when the transition animation completes',
+          (tester) async {
+        final animation = FakeAnimation();
+        final route = FakeRoute(
+          const RouteSettings(name: 'route'),
+          animation: animation,
+        );
+        observer.didPush(route, null);
+        await tester.pump();
+
+        verifyNever(
+          () => mockTransitionSpan.stop(endTimeMs: any(named: 'endTimeMs')),
+        );
+
+        animation.fireStatus(AnimationStatus.completed);
+
+        verify(
+          () => mockTransitionSpan.stop(endTimeMs: any(named: 'endTimeMs')),
+        ).called(1);
+      });
+
+      testWidgets('ends the span if the transition is interrupted (dismissed)',
+          (tester) async {
+        final animation = FakeAnimation();
+        final route = FakeRoute(
+          const RouteSettings(name: 'route'),
+          animation: animation,
+        );
+        observer.didPush(route, null);
+        await tester.pump();
+
+        animation.fireStatus(AnimationStatus.dismissed);
+
+        verify(
+          () => mockTransitionSpan.stop(endTimeMs: any(named: 'endTimeMs')),
+        ).called(1);
+      });
+
+      testWidgets(
+          'ends the span immediately if the animation is already complete',
+          (tester) async {
+        final animation = FakeAnimation(status: AnimationStatus.completed);
+        final route = FakeRoute(
+          const RouteSettings(name: 'route'),
+          animation: animation,
+        );
+        observer.didPush(route, null);
+        await tester.pump();
+
+        verify(
+          () => mockTransitionSpan.stop(endTimeMs: any(named: 'endTimeMs')),
+        ).called(1);
+      });
+
+      testWidgets('does not start a transition span when route name is null',
+          (tester) async {
+        final route = FakeRoute(const RouteSettings());
+        observer.didPush(route, null);
+        await tester.pump();
+
+        verifyNever(
+          () => mockEmbrace.startSpan(
+            any(),
+            startTimeMs: any(named: 'startTimeMs'),
+          ),
+        );
+      });
+
+      testWidgets('starts a span named after the route on replace',
+          (tester) async {
+        final animation = FakeAnimation();
+        final newRoute = FakeRoute(
+          const RouteSettings(name: 'route'),
+          animation: animation,
+        );
+        observer.didReplace(newRoute: newRoute);
+        await tester.pump();
+
+        verify(
+          () => mockEmbrace.startSpan(
+            'route',
+            startTimeMs: any(named: 'startTimeMs'),
+          ),
+        ).called(1);
+
+        animation.fireStatus(AnimationStatus.completed);
+        verify(
+          () => mockTransitionSpan.stop(endTimeMs: any(named: 'endTimeMs')),
+        ).called(1);
+      });
+
+      testWidgets(
+          'does not start a transition span when newRoute is null on replace',
+          (tester) async {
+        final oldRoute = FakeRoute(const RouteSettings(name: 'route'));
+        observer.didReplace(oldRoute: oldRoute);
+        await tester.pump();
+
+        verifyNever(
+          () => mockEmbrace.startSpan(
+            any(),
+            startTimeMs: any(named: 'startTimeMs'),
+          ),
+        );
+      });
+
+      testWidgets('transition span uses name from routeSettingsExtractor',
+          (tester) async {
+        final observer = EmbraceNavigationObserver(
+          routeSettingsExtractor: (route) =>
+              RouteSettings(name: route.settings.name?.toUpperCase()),
+        );
+        final route = FakeRoute(const RouteSettings(name: 'route'));
+        observer.didPush(route, null);
+        await tester.pump();
+
+        verify(
+          () => mockEmbrace.startSpan(
+            'ROUTE',
+            startTimeMs: any(named: 'startTimeMs'),
+          ),
+        ).called(1);
+      });
+
+      testWidgets('does not start a transition span on pop', (tester) async {
+        final route = FakeRoute(const RouteSettings(name: 'route'));
+        final previousRoute =
+            FakeRoute(const RouteSettings(name: 'previousRoute'));
+        observer.didPop(route, previousRoute);
+        await tester.pump();
+
+        verifyNever(
+          () => mockEmbrace.startSpan(
+            any(),
+            startTimeMs: any(named: 'startTimeMs'),
+          ),
+        );
       });
     });
   });

--- a/embrace/test/src/observer_test_helpers.dart
+++ b/embrace/test/src/observer_test_helpers.dart
@@ -19,9 +19,39 @@ class MockEmbraceSpan extends Mock implements EmbraceSpan {
   Future<String?> get traceId => Future.value();
 }
 
-class FakeRoute extends Fake implements Route<dynamic> {
-  FakeRoute(this.settings);
+class FakeRoute extends Fake implements TransitionRoute<dynamic> {
+  FakeRoute(this.settings, {Animation<double>? animation})
+      : animation = animation ?? FakeAnimation();
 
   @override
   final RouteSettings settings;
+
+  @override
+  final Animation<double>? animation;
+}
+
+class FakeAnimation extends Fake implements Animation<double> {
+  FakeAnimation({this.status = AnimationStatus.forward});
+
+  @override
+  AnimationStatus status;
+
+  final List<AnimationStatusListener> _listeners = [];
+
+  @override
+  void addStatusListener(AnimationStatusListener listener) {
+    _listeners.add(listener);
+  }
+
+  @override
+  void removeStatusListener(AnimationStatusListener listener) {
+    _listeners.remove(listener);
+  }
+
+  void fireStatus(AnimationStatus newStatus) {
+    status = newStatus;
+    for (final listener in List<AnimationStatusListener>.of(_listeners)) {
+      listener(newStatus);
+    }
+  }
 }


### PR DESCRIPTION
## Summary
- `EmbraceNavigationObserver` now starts an OTel span named after the route on `didPush`/`didReplace`, tagged `emb.type: 'view'`, ending when the route's transition animation reaches `completed` or `dismissed`
- Removes the legacy `startView`/`endView` platform-channel calls from this observer
- No span is started on `didPop` (intentional — pop isn't a screen "load")
- Duplicate-suppression is intentionally out of scope for this PR

Implements EMBR-12641. The go_router alignment (EMBR-12644) is separate follow-up work and not included here — `EmbraceGoRouterObserver`'s own NavigatorObserver-mode branch still uses the legacy API until that ticket updates it.

## Test plan
- [x] `dart analyze` clean on changed files
- [x] `flutter test` — all existing + new tests pass (push/replace, custom `routeSettingsExtractor`, unnamed-route guard, no-span-on-pop, normal completion and interrupted/dismissed transition)