### PR TITLE
Add screen-load span timed from last touch to first frame

### DIFF
--- a/embrace/CHANGELOG.md
+++ b/embrace/CHANGELOG.md
@@ -1,6 +1,7 @@
 # 4.8.0
 
 * Version bump
+* Added a screen-load span to `EmbraceNavigationObserver`, timed from the last user touch to the first frame of the new route
 
 # 4.7.0
 

--- a/embrace/lib/embrace.dart
+++ b/embrace/lib/embrace.dart
@@ -6,6 +6,7 @@ import 'package:dartastic_opentelemetry_api/dartastic_opentelemetry_api.dart'
 import 'package:embrace/embrace_api.dart';
 import 'package:embrace/src/embrace_startup_tracker.dart';
 import 'package:embrace/src/otel/otel.dart';
+import 'package:embrace/src/pointer_input_tracker.dart';
 import 'package:embrace_platform_interface/embrace_platform_interface.dart';
 import 'package:embrace_platform_interface/last_run_end_state.dart';
 import 'package:flutter/widgets.dart';
@@ -548,6 +549,7 @@ Future<void> _start(
 ) async {
   WidgetsFlutterBinding.ensureInitialized();
   EmbraceStartupTracker.init();
+  EmbracePointerInputTracker.init();
 
   if (OTelFactory.otelFactory == null) {
     OTelAPI.initialize(

--- a/embrace/lib/src/navigation_observer.dart
+++ b/embrace/lib/src/navigation_observer.dart
@@ -1,5 +1,6 @@
 import 'package:embrace/embrace.dart';
 import 'package:embrace/embrace_api.dart';
+import 'package:embrace/src/pointer_input_tracker.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/scheduler.dart';
 
@@ -7,6 +8,20 @@ import 'package:flutter/scheduler.dart';
 typedef EmbraceRouteSettingsExtractor = RouteSettings? Function(
   Route<dynamic> route,
 );
+
+/// Configuration for the screen-load span timing recorded by
+/// [EmbraceNavigationObserver].
+class EmbraceScreenLoadConfig {
+  /// Creates a screen-load span timing configuration.
+  const EmbraceScreenLoadConfig({
+    this.recencyThreshold = const Duration(seconds: 1),
+  });
+
+  /// How old a recorded touch can be and still count as the input that
+  /// triggered a route transition. If the last touch is older than this,
+  /// the span falls back to using the route-push time as its start.
+  final Duration recencyThreshold;
+}
 
 /// {@template embrace_navigation_observer}
 /// A [NavigatorObserver] that automatically tracks app navigation
@@ -40,6 +55,7 @@ class EmbraceNavigationObserver extends RouteObserver<ModalRoute<dynamic>> {
   /// {@macro embrace_navigation_observer}
   EmbraceNavigationObserver({
     EmbraceRouteSettingsExtractor? routeSettingsExtractor,
+    this.screenLoadConfig = const EmbraceScreenLoadConfig(),
   }) : routeSettingsExtractor = routeSettingsExtractor ?? _defaultExtractor;
 
   /// A function that returns the settings from a given route
@@ -49,8 +65,48 @@ class EmbraceNavigationObserver extends RouteObserver<ModalRoute<dynamic>> {
   /// or return null to avoid tracking a specific view
   final EmbraceRouteSettingsExtractor? routeSettingsExtractor;
 
+  /// Configuration for the screen-load span timing.
+  final EmbraceScreenLoadConfig screenLoadConfig;
+
   static RouteSettings? _defaultExtractor(Route<dynamic> route) {
     return route.settings;
+  }
+
+  void _startScreenLoadSpan(String routeName) {
+    final startTimeMs = EmbracePointerInputTracker.resolveStartTimeMs(
+      DateTime.now(),
+      screenLoadConfig.recencyThreshold,
+    );
+    int? endTimeMs;
+    EmbraceSpan? pendingSpan;
+
+    void tryStop() {
+      final span = pendingSpan;
+      final endMs = endTimeMs;
+      if (span != null && endMs != null) {
+        span.stop(endTimeMs: endMs);
+      }
+    }
+
+    Embrace.instance
+        .startSpan(
+      routeName,
+      startTimeMs: startTimeMs,
+    )
+        .then(
+      (span) {
+        pendingSpan = span;
+        span?.addAttribute('emb.type', 'view');
+        tryStop();
+      },
+      onError: (_, __) {},
+    );
+
+    SchedulerBinding.instance.addPostFrameCallback((_) {
+      endTimeMs = DateTime.now().millisecondsSinceEpoch;
+      tryStop();
+    });
+    SchedulerBinding.instance.scheduleFrame();
   }
 
   void _startTtiSpan(String routeName) {
@@ -112,6 +168,7 @@ class EmbraceNavigationObserver extends RouteObserver<ModalRoute<dynamic>> {
     final routeName = routeSettingsExtractor?.call(route)?.name;
     if (routeName != null) {
       _startTtiSpan(routeName);
+      _startScreenLoadSpan(routeName);
     }
   }
 
@@ -123,6 +180,7 @@ class EmbraceNavigationObserver extends RouteObserver<ModalRoute<dynamic>> {
         newRoute != null ? routeSettingsExtractor?.call(newRoute)?.name : null;
     if (routeName != null) {
       _startTtiSpan(routeName);
+      _startScreenLoadSpan(routeName);
     }
   }
 

--- a/embrace/lib/src/pointer_input_tracker.dart
+++ b/embrace/lib/src/pointer_input_tracker.dart
@@ -1,0 +1,71 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter/gestures.dart';
+
+/// Passively tracks the timestamp of the most recent user touch, so that
+/// route transitions can be timed from the input that triggered them rather
+/// than the moment the route was pushed.
+///
+/// Registers a global pointer route once at SDK startup, covering the whole
+/// app with no widget-tree wrapping required.
+class EmbracePointerInputTracker {
+  static bool _initialized = false;
+  static DateTime? _lastPointerEventTime;
+
+  /// Registers the global pointer route. Safe to call multiple times — only
+  /// the first call registers the handler.
+  static void init() {
+    if (_initialized) return;
+    _initialized = true;
+    GestureBinding.instance.pointerRouter.addGlobalRoute(_onPointerEvent);
+  }
+
+  static void _onPointerEvent(PointerEvent event) {
+    if (event is PointerDownEvent || event is PointerUpEvent) {
+      _lastPointerEventTime = DateTime.now();
+    }
+  }
+
+  /// Resolves the start time to use for a route transition span.
+  ///
+  /// If a qualifying touch was recorded within [recencyThreshold] of
+  /// [pushTime], its timestamp is consumed (cleared) and returned so a
+  /// later, unrelated push can't reuse it. Otherwise [pushTime] is returned.
+  static int resolveStartTimeMs(DateTime pushTime, Duration recencyThreshold) {
+    final lastEventTime = _lastPointerEventTime;
+    if (lastEventTime == null) {
+      return pushTime.millisecondsSinceEpoch;
+    }
+
+    final delta = pushTime.difference(lastEventTime);
+    if (delta < Duration.zero || delta > recencyThreshold) {
+      return pushTime.millisecondsSinceEpoch;
+    }
+
+    _lastPointerEventTime = null;
+    return lastEventTime.millisecondsSinceEpoch;
+  }
+
+  /// The stored last-pointer-event time.
+  @visibleForTesting
+  static DateTime? get debugLastPointerEventTime => _lastPointerEventTime;
+
+  /// Directly sets the stored last-pointer-event time, bypassing real
+  /// gesture dispatch.
+  @visibleForTesting
+  static set debugLastPointerEventTime(DateTime? value) {
+    _lastPointerEventTime = value;
+  }
+
+  /// Resets all static state, including unregistering the global route if
+  /// [init] was called. Intended for use in test `tearDown`.
+  @visibleForTesting
+  static void resetForTesting() {
+    if (_initialized) {
+      GestureBinding.instance.pointerRouter.removeGlobalRoute(
+        _onPointerEvent,
+      );
+    }
+    _initialized = false;
+    _lastPointerEventTime = null;
+  }
+}

--- a/embrace/test/src/navigation_observer_test.dart
+++ b/embrace/test/src/navigation_observer_test.dart
@@ -132,6 +132,7 @@ void main() {
     group('TTI spans', () {
       late MockEmbrace mockEmbrace;
       late MockEmbraceSpan mockSpan;
+      late MockEmbraceSpan screenLoadSpanStub;
 
       setUpAll(() {
         registerFallbackValue('');
@@ -140,10 +141,22 @@ void main() {
       setUp(() {
         mockEmbrace = MockEmbrace();
         mockSpan = MockEmbraceSpan();
+        screenLoadSpanStub = MockEmbraceSpan();
         // ignore: invalid_use_of_visible_for_testing_member
         debugEmbraceOverride = mockEmbrace;
         when(() => mockEmbrace.startView(any())).thenAnswer((_) {});
         when(() => mockEmbrace.endView(any())).thenAnswer((_) {});
+        // didPush/didReplace also start a screen-load span (see the
+        // 'screen load spans' group below) — stub a catch-all for it here
+        // too so it doesn't throw, without affecting this group's TTI
+        // assertions. Registered before the exact TTI stub below, which
+        // overrides it for that specific call.
+        when(
+          () => mockEmbrace.startSpan(
+            any(),
+            startTimeMs: any(named: 'startTimeMs'),
+          ),
+        ).thenAnswer((_) => Future.value(screenLoadSpanStub));
         when(
           () => mockEmbrace.startSpan(
             'emb-time-to-interactive-flutter',
@@ -153,6 +166,10 @@ void main() {
         when(() => mockSpan.addAttribute(any(), any()))
             .thenAnswer((_) async => true);
         when(() => mockSpan.stop(endTimeMs: any(named: 'endTimeMs')))
+            .thenAnswer((_) async => true);
+        when(() => screenLoadSpanStub.addAttribute(any(), any()))
+            .thenAnswer((_) async => true);
+        when(() => screenLoadSpanStub.stop(endTimeMs: any(named: 'endTimeMs')))
             .thenAnswer((_) async => true);
       });
 
@@ -227,6 +244,144 @@ void main() {
       });
 
       testWidgets('does not start a TTI span on pop', (tester) async {
+        final route = FakeRoute(const RouteSettings(name: 'route'));
+        final previousRoute =
+            FakeRoute(const RouteSettings(name: 'previousRoute'));
+        observer.didPop(route, previousRoute);
+        await tester.pump();
+
+        verifyNever(() => mockEmbrace.startSpan(any()));
+      });
+    });
+
+    group('screen load spans', () {
+      late MockEmbrace mockEmbrace;
+      late MockEmbraceSpan screenLoadSpan;
+      late MockEmbraceSpan ttiSpan;
+
+      setUpAll(() {
+        registerFallbackValue('');
+      });
+
+      setUp(() {
+        mockEmbrace = MockEmbrace();
+        screenLoadSpan = MockEmbraceSpan();
+        ttiSpan = MockEmbraceSpan();
+        // ignore: invalid_use_of_visible_for_testing_member
+        debugEmbraceOverride = mockEmbrace;
+        when(() => mockEmbrace.startView(any())).thenAnswer((_) {});
+        when(() => mockEmbrace.endView(any())).thenAnswer((_) {});
+        // didPush/didReplace also start a TTI span (see the 'TTI spans'
+        // group above) — stub a catch-all for it here so it doesn't throw,
+        // without this group's tests needing to know its name. Each test
+        // below overrides this for the specific route name it exercises.
+        when(
+          () => mockEmbrace.startSpan(
+            any(),
+            startTimeMs: any(named: 'startTimeMs'),
+          ),
+        ).thenAnswer((_) => Future.value(ttiSpan));
+        when(() => ttiSpan.addAttribute(any(), any()))
+            .thenAnswer((_) async => true);
+        when(() => ttiSpan.stop(endTimeMs: any(named: 'endTimeMs')))
+            .thenAnswer((_) async => true);
+        when(() => screenLoadSpan.addAttribute(any(), any()))
+            .thenAnswer((_) async => true);
+        when(() => screenLoadSpan.stop(endTimeMs: any(named: 'endTimeMs')))
+            .thenAnswer((_) async => true);
+      });
+
+      void stubScreenLoadSpan(String routeName) {
+        when(
+          () => mockEmbrace.startSpan(
+            routeName,
+            startTimeMs: any(named: 'startTimeMs'),
+          ),
+        ).thenAnswer((_) => Future.value(screenLoadSpan));
+      }
+
+      tearDown(() {
+        // ignore: invalid_use_of_visible_for_testing_member
+        debugEmbraceOverride = null;
+      });
+
+      testWidgets('starts a span named after the route on push',
+          (tester) async {
+        stubScreenLoadSpan('route');
+        final route = FakeRoute(const RouteSettings(name: 'route'));
+        observer.didPush(route, null);
+        await tester.pump();
+
+        verify(
+          () => mockEmbrace.startSpan(
+            'route',
+            startTimeMs: any(named: 'startTimeMs'),
+          ),
+        ).called(1);
+        verify(() => screenLoadSpan.addAttribute('emb.type', 'view'))
+            .called(1);
+        verify(
+          () => screenLoadSpan.stop(endTimeMs: any(named: 'endTimeMs')),
+        ).called(1);
+      });
+
+      testWidgets('span name uses name from routeSettingsExtractor',
+          (tester) async {
+        stubScreenLoadSpan('ROUTE');
+        final observer = EmbraceNavigationObserver(
+          routeSettingsExtractor: (route) =>
+              RouteSettings(name: route.settings.name?.toUpperCase()),
+        );
+        final route = FakeRoute(const RouteSettings(name: 'route'));
+        observer.didPush(route, null);
+        await tester.pump();
+
+        verify(
+          () => mockEmbrace.startSpan(
+            'ROUTE',
+            startTimeMs: any(named: 'startTimeMs'),
+          ),
+        ).called(1);
+      });
+
+      testWidgets('does not start a span when route name is null',
+          (tester) async {
+        final route = FakeRoute(const RouteSettings());
+        observer.didPush(route, null);
+        await tester.pump();
+
+        verifyNever(() => mockEmbrace.startSpan(any()));
+      });
+
+      testWidgets('starts a span on replace', (tester) async {
+        stubScreenLoadSpan('route');
+        final newRoute = FakeRoute(const RouteSettings(name: 'route'));
+        observer.didReplace(newRoute: newRoute);
+        await tester.pump();
+
+        verify(
+          () => mockEmbrace.startSpan(
+            'route',
+            startTimeMs: any(named: 'startTimeMs'),
+          ),
+        ).called(1);
+        verify(() => screenLoadSpan.addAttribute('emb.type', 'view'))
+            .called(1);
+        verify(
+          () => screenLoadSpan.stop(endTimeMs: any(named: 'endTimeMs')),
+        ).called(1);
+      });
+
+      testWidgets('does not start a span when newRoute is null on replace',
+          (tester) async {
+        final oldRoute = FakeRoute(const RouteSettings(name: 'route'));
+        observer.didReplace(oldRoute: oldRoute);
+        await tester.pump();
+
+        verifyNever(() => mockEmbrace.startSpan(any()));
+      });
+
+      testWidgets('does not start a span on pop', (tester) async {
         final route = FakeRoute(const RouteSettings(name: 'route'));
         final previousRoute =
             FakeRoute(const RouteSettings(name: 'previousRoute'));

--- a/embrace/test/src/navigation_observer_test.dart
+++ b/embrace/test/src/navigation_observer_test.dart
@@ -318,8 +318,7 @@ void main() {
             startTimeMs: any(named: 'startTimeMs'),
           ),
         ).called(1);
-        verify(() => screenLoadSpan.addAttribute('emb.type', 'view'))
-            .called(1);
+        verify(() => screenLoadSpan.addAttribute('emb.type', 'view')).called(1);
         verify(
           () => screenLoadSpan.stop(endTimeMs: any(named: 'endTimeMs')),
         ).called(1);
@@ -365,8 +364,7 @@ void main() {
             startTimeMs: any(named: 'startTimeMs'),
           ),
         ).called(1);
-        verify(() => screenLoadSpan.addAttribute('emb.type', 'view'))
-            .called(1);
+        verify(() => screenLoadSpan.addAttribute('emb.type', 'view')).called(1);
         verify(
           () => screenLoadSpan.stop(endTimeMs: any(named: 'endTimeMs')),
         ).called(1);

--- a/embrace/test/src/pointer_input_tracker_test.dart
+++ b/embrace/test/src/pointer_input_tracker_test.dart
@@ -1,0 +1,148 @@
+import 'package:embrace/src/pointer_input_tracker.dart';
+import 'package:flutter/gestures.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  tearDown(EmbracePointerInputTracker.resetForTesting);
+
+  group('EmbracePointerInputTracker', () {
+    group('init', () {
+      testWidgets('can be called more than once without throwing',
+          (tester) async {
+        expect(EmbracePointerInputTracker.init, returnsNormally);
+        expect(EmbracePointerInputTracker.init, returnsNormally);
+      });
+
+      testWidgets('captures PointerDownEvent dispatched via the global route',
+          (tester) async {
+        EmbracePointerInputTracker.init();
+
+        GestureBinding.instance.pointerRouter.route(const PointerDownEvent());
+
+        final pushTime = DateTime.now().add(const Duration(milliseconds: 1));
+        final startTimeMs = EmbracePointerInputTracker.resolveStartTimeMs(
+          pushTime,
+          const Duration(seconds: 1),
+        );
+
+        expect(startTimeMs, isNot(pushTime.millisecondsSinceEpoch));
+      });
+
+      testWidgets('captures PointerUpEvent dispatched via the global route',
+          (tester) async {
+        EmbracePointerInputTracker.init();
+
+        GestureBinding.instance.pointerRouter.route(const PointerUpEvent());
+
+        final pushTime = DateTime.now().add(const Duration(milliseconds: 1));
+        final startTimeMs = EmbracePointerInputTracker.resolveStartTimeMs(
+          pushTime,
+          const Duration(seconds: 1),
+        );
+
+        expect(startTimeMs, isNot(pushTime.millisecondsSinceEpoch));
+      });
+
+      testWidgets('ignores other pointer event types', (tester) async {
+        EmbracePointerInputTracker.init();
+
+        GestureBinding.instance.pointerRouter.route(const PointerMoveEvent());
+
+        final pushTime = DateTime.now();
+        final startTimeMs = EmbracePointerInputTracker.resolveStartTimeMs(
+          pushTime,
+          const Duration(seconds: 1),
+        );
+
+        expect(startTimeMs, pushTime.millisecondsSinceEpoch);
+      });
+    });
+
+    group('resolveStartTimeMs', () {
+      test('falls back to push time when no input was ever recorded', () {
+        final pushTime = DateTime.now();
+
+        final startTimeMs = EmbracePointerInputTracker.resolveStartTimeMs(
+          pushTime,
+          const Duration(seconds: 1),
+        );
+
+        expect(startTimeMs, pushTime.millisecondsSinceEpoch);
+      });
+
+      test('uses the recorded input time when within the recency threshold',
+          () {
+        final pushTime = DateTime.now();
+        final inputTime = pushTime.subtract(const Duration(milliseconds: 500));
+        EmbracePointerInputTracker.debugLastPointerEventTime = inputTime;
+
+        final startTimeMs = EmbracePointerInputTracker.resolveStartTimeMs(
+          pushTime,
+          const Duration(seconds: 1),
+        );
+
+        expect(startTimeMs, inputTime.millisecondsSinceEpoch);
+      });
+
+      test('consumes the recorded input time so it cannot be reused', () {
+        final pushTime = DateTime.now();
+        final inputTime = pushTime.subtract(const Duration(milliseconds: 500));
+        EmbracePointerInputTracker.debugLastPointerEventTime = inputTime;
+
+        EmbracePointerInputTracker.resolveStartTimeMs(
+          pushTime,
+          const Duration(seconds: 1),
+        );
+        final secondPushTime = pushTime.add(const Duration(milliseconds: 10));
+        final secondStartTimeMs = EmbracePointerInputTracker.resolveStartTimeMs(
+          secondPushTime,
+          const Duration(seconds: 1),
+        );
+
+        expect(secondStartTimeMs, secondPushTime.millisecondsSinceEpoch);
+      });
+
+      test('falls back to push time exactly at the recency threshold', () {
+        final pushTime = DateTime.now();
+        final inputTime = pushTime.subtract(const Duration(seconds: 1));
+        EmbracePointerInputTracker.debugLastPointerEventTime = inputTime;
+
+        final startTimeMs = EmbracePointerInputTracker.resolveStartTimeMs(
+          pushTime,
+          const Duration(seconds: 1),
+        );
+
+        expect(startTimeMs, inputTime.millisecondsSinceEpoch);
+      });
+
+      test('falls back to push time when input is older than the threshold',
+          () {
+        final pushTime = DateTime.now();
+        final inputTime = pushTime.subtract(
+          const Duration(seconds: 1, milliseconds: 1),
+        );
+        EmbracePointerInputTracker.debugLastPointerEventTime = inputTime;
+
+        final startTimeMs = EmbracePointerInputTracker.resolveStartTimeMs(
+          pushTime,
+          const Duration(seconds: 1),
+        );
+
+        expect(startTimeMs, pushTime.millisecondsSinceEpoch);
+      });
+
+      test('falls back to push time when input is after push time', () {
+        final pushTime = DateTime.now();
+        final inputTime = pushTime.add(const Duration(milliseconds: 500));
+        EmbracePointerInputTracker.debugLastPointerEventTime = inputTime;
+
+        final startTimeMs = EmbracePointerInputTracker.resolveStartTimeMs(
+          pushTime,
+          const Duration(seconds: 1),
+        );
+
+        expect(startTimeMs, pushTime.millisecondsSinceEpoch);
+      });
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- Adds a new OTel span per named route transition in `EmbraceNavigationObserver`, timed to reflect user-perceived navigation latency rather than internal transition mechanics.
- Span start time is the timestamp of the last `PointerDownEvent`/`PointerUpEvent` seen by a global pointer route registered at SDK startup, if it falls within a 1s recency threshold (configurable via `EmbraceScreenLoadConfig`); otherwise falls back to route-push time.
- Span end time reuses the existing post-frame-callback signal (same as the existing TTI span) as an interim "interactable" proxy for v1.
- Span name is the route name itself, tagged `emb.type: 'view'`.
- This is additive — the existing `emb-time-to-interactive-flutter` TTI span is untouched.
- Out of scope: `embrace_go_router`'s observer (separate follow-up ticket, blocked on this span schema).

## Test plan
- [x] `flutter test` passes (244 tests) in `embrace/`
- [x] `flutter analyze` clean on all touched files
- [x] New unit tests for `EmbracePointerInputTracker` (real pointer dispatch via `GestureBinding`, idempotent `init()`, recency-threshold edge cases, timestamp consumption)
- [x] Extended `navigation_observer_test.dart` with a new "screen load spans" group covering push/replace/pop and `routeSettingsExtractor` behavior