### PR TITLE
Fix TTI span to fire once at launch instead of every route transition

### DIFF
--- a/embrace/lib/src/embrace_startup_tracker.dart
+++ b/embrace/lib/src/embrace_startup_tracker.dart
@@ -11,6 +11,10 @@ class EmbraceStartupTracker {
   static Stopwatch? _stopwatch;
   static int? _startEpochMs;
 
+  /// The wall-clock timestamp (epoch ms) captured by [init], or `null` if
+  /// [init] hasn't been called yet.
+  static int? get startEpochMs => _startEpochMs;
+
   /// Captures the start timestamp. Must be called as early as possible in the
   /// SDK lifecycle, before [recordFirstFrame]. Safe to call multiple times —
   /// only the first call sets the timestamp.
@@ -34,5 +38,12 @@ class EmbraceStartupTracker {
       startEpochMs,
       startEpochMs + elapsedMs,
     );
+  }
+
+  /// Resets all static state. Intended for use in test `tearDown`.
+  @visibleForTesting
+  static void resetForTesting() {
+    _stopwatch = null;
+    _startEpochMs = null;
   }
 }

--- a/embrace/lib/src/navigation_observer.dart
+++ b/embrace/lib/src/navigation_observer.dart
@@ -1,5 +1,6 @@
 import 'package:embrace/embrace.dart';
 import 'package:embrace/embrace_api.dart';
+import 'package:embrace/src/embrace_startup_tracker.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/scheduler.dart';
 
@@ -53,8 +54,21 @@ class EmbraceNavigationObserver extends RouteObserver<ModalRoute<dynamic>> {
     return route.settings;
   }
 
+  static bool _ttiSpanStarted = false;
+
+  /// Resets the one-shot TTI span state. Intended for use in test
+  /// `tearDown`.
+  @visibleForTesting
+  static void resetTtiSpanForTesting() {
+    _ttiSpanStarted = false;
+  }
+
   void _startTtiSpan(String routeName) {
-    final startTimeMs = DateTime.now().millisecondsSinceEpoch;
+    if (_ttiSpanStarted) return;
+    _ttiSpanStarted = true;
+
+    final startTimeMs = EmbraceStartupTracker.startEpochMs ??
+        DateTime.now().millisecondsSinceEpoch;
     int? endTimeMs;
     EmbraceSpan? pendingSpan;
 

--- a/embrace/test/src/navigation_observer_test.dart
+++ b/embrace/test/src/navigation_observer_test.dart
@@ -1,4 +1,5 @@
 import 'package:embrace/embrace.dart';
+import 'package:embrace/src/embrace_startup_tracker.dart';
 import 'package:embrace_platform_interface/embrace_platform_interface.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -12,6 +13,15 @@ void main() {
   setUp(() {
     observer = EmbraceNavigationObserver();
   });
+
+  // The TTI span's one-shot guard is static/global — reset it after every
+  // test in this file, not just the ones that exercise it directly, since
+  // any didPush/didReplace call (e.g. in the 'view tracking' group) trips
+  // it too.
+  tearDown(
+    // ignore: invalid_use_of_visible_for_testing_member
+    EmbraceNavigationObserver.resetTtiSpanForTesting,
+  );
 
   group('EmbraceNavigationObserver', () {
     group('view tracking', () {
@@ -159,6 +169,8 @@ void main() {
       tearDown(() {
         // ignore: invalid_use_of_visible_for_testing_member
         debugEmbraceOverride = null;
+        // ignore: invalid_use_of_visible_for_testing_member
+        EmbraceStartupTracker.resetForTesting();
       });
 
       testWidgets('starts a TTI span on push', (tester) async {
@@ -234,6 +246,40 @@ void main() {
         await tester.pump();
 
         verifyNever(() => mockEmbrace.startSpan(any()));
+      });
+
+      testWidgets('only starts the TTI span once, on the first navigation',
+          (tester) async {
+        final firstRoute = FakeRoute(const RouteSettings(name: 'first'));
+        final secondRoute = FakeRoute(const RouteSettings(name: 'second'));
+        observer.didPush(firstRoute, null);
+        await tester.pump();
+        observer.didPush(secondRoute, firstRoute);
+        await tester.pump();
+
+        verify(
+          () => mockEmbrace.startSpan(
+            'emb-time-to-interactive-flutter',
+            startTimeMs: any(named: 'startTimeMs'),
+          ),
+        ).called(1);
+      });
+
+      testWidgets('uses the app-launch timestamp as the start time',
+          (tester) async {
+        EmbraceStartupTracker.init();
+        final launchEpochMs = EmbraceStartupTracker.startEpochMs;
+
+        final route = FakeRoute(const RouteSettings(name: 'route'));
+        observer.didPush(route, null);
+        await tester.pump();
+
+        verify(
+          () => mockEmbrace.startSpan(
+            'emb-time-to-interactive-flutter',
+            startTimeMs: launchEpochMs,
+          ),
+        ).called(1);
       });
     });
   });


### PR DESCRIPTION
## Summary
- `emb-time-to-interactive-flutter` (`_startTtiSpan` in `EmbraceNavigationObserver`) is intended to measure app launch → first screen interacted with, once per app run. It was actually firing on every `didPush`/`didReplace`, using push-time as its start instead of app-launch time.
- Adds a static one-shot guard so the span only starts on the first qualifying navigation after launch.
- Anchors the span's start time to `EmbraceStartupTracker.startEpochMs` (the same app-launch timestamp used by `emb-time-to-first-frame-flutter`), falling back to push-time if the startup tracker hasn't been initialized.
- `embrace_go_router`'s duplicate `_startTtiSpan` implementation has the same issue but is not touched here — separate, out of scope for this fix.

## Test plan
- [x] `flutter test` passes (230 tests) in `embrace/`
- [x] `flutter analyze` clean on all touched files
- [x] New test: TTI span only starts once across multiple `didPush` calls
- [x] New test: TTI span start time comes from `EmbraceStartupTracker.startEpochMs` when available