### PR TITLE
Fix go_router TTI span to fire once at launch instead of every navigation

### DIFF
--- a/embrace/lib/src/embrace_startup_tracker.dart
+++ b/embrace/lib/src/embrace_startup_tracker.dart
@@ -11,6 +11,10 @@ class EmbraceStartupTracker {
   static Stopwatch? _stopwatch;
   static int? _startEpochMs;
 
+  /// The wall-clock timestamp (epoch ms) captured by [init], or `null` if
+  /// [init] hasn't been called yet.
+  static int? get startEpochMs => _startEpochMs;
+
   /// Captures the start timestamp. Must be called as early as possible in the
   /// SDK lifecycle, before [recordFirstFrame]. Safe to call multiple times —
   /// only the first call sets the timestamp.

--- a/embrace_go_router/lib/src/go_router_observer.dart
+++ b/embrace_go_router/lib/src/go_router_observer.dart
@@ -1,5 +1,7 @@
 import 'package:embrace/embrace.dart';
 import 'package:embrace/embrace_api.dart';
+// ignore: implementation_imports
+import 'package:embrace/src/embrace_startup_tracker.dart';
 import 'package:flutter/scheduler.dart';
 import 'package:flutter/widgets.dart';
 import 'package:go_router/go_router.dart';
@@ -82,6 +84,15 @@ class EmbraceGoRouterObserver extends NavigatorObserver {
     return route.settings;
   }
 
+  static bool _ttiSpanStarted = false;
+
+  /// Resets the one-shot TTI span state. Intended for use in test
+  /// `tearDown`.
+  @visibleForTesting
+  static void resetTtiSpanForTesting() {
+    _ttiSpanStarted = false;
+  }
+
   void _reportCurrentRoute() {
     if (_router == null) return;
     final name = _router!.routeInformationProvider.value.uri.path;
@@ -157,6 +168,11 @@ class EmbraceGoRouterObserver extends NavigatorObserver {
   }
 
   void _startTtiSpan(String routeName) {
+    if (_ttiSpanStarted) return;
+    _ttiSpanStarted = true;
+
+    final startTimeMs = EmbraceStartupTracker.startEpochMs ??
+        DateTime.now().millisecondsSinceEpoch;
     int? endTimeMs;
     EmbraceSpan? pendingSpan;
 
@@ -170,7 +186,9 @@ class EmbraceGoRouterObserver extends NavigatorObserver {
       }
     }
 
-    Embrace.instance.startSpan('emb-time-to-interactive-flutter').then(
+    Embrace.instance
+        .startSpan('emb-time-to-interactive-flutter', startTimeMs: startTimeMs)
+        .then(
       (span) {
         pendingSpan = span;
         tryStop();

--- a/embrace_go_router/test/go_router_observer_test.dart
+++ b/embrace_go_router/test/go_router_observer_test.dart
@@ -26,6 +26,15 @@ void main() {
     observer = EmbraceGoRouterObserver();
   });
 
+  // The TTI span's one-shot guard is static/global — reset it after every
+  // test in this file, not just the ones that exercise it directly, since
+  // any didPush/didReplace/route change (e.g. in the 'view tracking' and
+  // 'state span' groups) trips it too.
+  tearDown(
+    // ignore: invalid_use_of_visible_for_testing_member
+    EmbraceGoRouterObserver.resetTtiSpanForTesting,
+  );
+
   group('NavigatorObserver mode (no router)', () {
     group('view tracking', () {
       late MockEmbracePlatform platform;
@@ -123,8 +132,12 @@ void main() {
         debugEmbraceOverride = mockEmbrace;
         when(() => mockEmbrace.startView(any())).thenAnswer((_) {});
         when(() => mockEmbrace.endView(any())).thenAnswer((_) {});
-        when(() => mockEmbrace.startSpan('emb-time-to-interactive-flutter'))
-            .thenAnswer((_) => Future.value(mockSpan));
+        when(
+          () => mockEmbrace.startSpan(
+            'emb-time-to-interactive-flutter',
+            startTimeMs: any(named: 'startTimeMs'),
+          ),
+        ).thenAnswer((_) => Future.value(mockSpan));
         when(() => mockSpan.addAttribute(any(), any()))
             .thenAnswer((_) async => true);
         when(() => mockSpan.stop(endTimeMs: any(named: 'endTimeMs')))
@@ -142,12 +155,34 @@ void main() {
         await tester.pump();
 
         verify(
-          () => mockEmbrace.startSpan('emb-time-to-interactive-flutter'),
+          () => mockEmbrace.startSpan(
+            'emb-time-to-interactive-flutter',
+            startTimeMs: any(named: 'startTimeMs'),
+          ),
         ).called(1);
         verify(() => mockSpan.addAttribute('route', '/route')).called(1);
         verify(
           () => mockSpan.stop(endTimeMs: any(named: 'endTimeMs')),
         ).called(1);
+      });
+
+      testWidgets('only starts the TTI span once, on the first navigation',
+          (tester) async {
+        final firstRoute = FakeRoute(const RouteSettings(name: '/first'));
+        final secondRoute = FakeRoute(const RouteSettings(name: '/second'));
+        observer.didPush(firstRoute, null);
+        await tester.pump();
+        observer.didPush(secondRoute, firstRoute);
+        await tester.pump();
+
+        verify(
+          () => mockEmbrace.startSpan(
+            'emb-time-to-interactive-flutter',
+            startTimeMs: any(named: 'startTimeMs'),
+          ),
+        ).called(1);
+        verify(() => mockSpan.addAttribute('route', '/first')).called(1);
+        verifyNever(() => mockSpan.addAttribute('route', '/second'));
       });
 
       testWidgets('TTI span uses name from routeSettingsExtractor',
@@ -178,7 +213,10 @@ void main() {
         await tester.pump();
 
         verify(
-          () => mockEmbrace.startSpan('emb-time-to-interactive-flutter'),
+          () => mockEmbrace.startSpan(
+            'emb-time-to-interactive-flutter',
+            startTimeMs: any(named: 'startTimeMs'),
+          ),
         ).called(1);
         verify(() => mockSpan.addAttribute('route', '/new')).called(1);
         verify(
@@ -226,7 +264,10 @@ void main() {
         () => mockEmbrace.startSpan('emb-state-screen-flutter-automatic'),
       ).thenAnswer((_) => Future.value(mockStateSpan));
       when(
-        () => mockEmbrace.startSpan('emb-time-to-interactive-flutter'),
+        () => mockEmbrace.startSpan(
+          'emb-time-to-interactive-flutter',
+          startTimeMs: any(named: 'startTimeMs'),
+        ),
       ).thenAnswer((_) => Future.value(mockTtiSpan));
       when(() => mockStateSpan.addAttribute(any(), any()))
           .thenAnswer((_) async => true);
@@ -391,7 +432,10 @@ void main() {
         await tester.pump();
 
         verify(
-          () => mockEmbrace.startSpan('emb-time-to-interactive-flutter'),
+          () => mockEmbrace.startSpan(
+            'emb-time-to-interactive-flutter',
+            startTimeMs: any(named: 'startTimeMs'),
+          ),
         ).called(1);
         verify(() => mockTtiSpan.addAttribute('route', '/')).called(1);
         verify(
@@ -399,7 +443,9 @@ void main() {
         ).called(1);
       });
 
-      testWidgets('starts a TTI span on route change', (tester) async {
+      testWidgets(
+          'does not start another TTI span on subsequent route '
+          'changes', (tester) async {
         final router = _buildRouter();
         await tester.pumpWidget(MaterialApp.router(routerConfig: router));
         final obs = EmbraceGoRouterObserver(router: router);
@@ -410,9 +456,12 @@ void main() {
         await tester.pump();
 
         verify(
-          () => mockEmbrace.startSpan('emb-time-to-interactive-flutter'),
-        ).called(2);
-        verify(() => mockTtiSpan.addAttribute('route', '/home')).called(1);
+          () => mockEmbrace.startSpan(
+            'emb-time-to-interactive-flutter',
+            startTimeMs: any(named: 'startTimeMs'),
+          ),
+        ).called(1);
+        verifyNever(() => mockTtiSpan.addAttribute('route', '/home'));
       });
     });
   });


### PR DESCRIPTION
## Summary
- `EmbraceGoRouterObserver`'s `_startTtiSpan` fired on every route push/replace/change, recording a new `emb-time-to-interactive-flutter` span per navigation instead of once for the app's actual first interactive screen.
- Adds a one-shot guard so the TTI span only fires on the first navigation after launch, and anchors its `startTimeMs` to the app-launch timestamp (`EmbraceStartupTracker.startEpochMs`) instead of the moment the route change was observed.
- Mirrors the same fix already applied to the base `EmbraceNavigationObserver` (Navigator-based apps), extending it to the go_router observer (both `NavigatorObserver` mode and delegate/`StatefulShellRoute` mode).

## Test plan
- [x] `embrace_go_router` test suite passes (26 tests), including new coverage for the one-shot behavior in both NavigatorObserver and delegate modes
- [x] `embrace` test suite passes (228 tests) — unaffected by this change
- [x] `flutter analyze` clean on both packages