### PR TITLE
fix(ci): add watchdog for silent VM Service hang in iOS integration test

### DIFF
--- a/.github/workflows/embrace.yaml
+++ b/.github/workflows/embrace.yaml
@@ -201,7 +201,7 @@ jobs:
     # ships an updated image with a matching host OS build.
     name: iOS (Flutter integration test, macOS-15)
     runs-on: macos-15
-    timeout-minutes: 45
+    timeout-minutes: 50
     defaults:
       run:
         working-directory: embrace/example
@@ -311,37 +311,62 @@ jobs:
           xcrun simctl status_bar "$UDID" override --time 9:41 || true
           xcrun simctl list devices | grep "$UDID"
       - name: Run iOS integration test
-        timeout-minutes: 25
+        timeout-minutes: 38
         env:
           SIM_UDID: ${{ steps.boot-sim.outputs.udid }}
         run: |
-          set -o pipefail
           xcrun simctl bootstatus "$SIM_UDID" -b
           flutter devices || true
 
-          # Sentinel-gated single retry: a transient "log reader failed unexpectedly"
-          # error during debug-attach is the only known-flaky failure mode. Anything
-          # else (compile error, test assertion, network) fails fast on attempt 1.
+          # Sentinel-gated retry covering two known-flaky CoreSimulator/Flutter failure
+          # modes: (a) "Error waiting for a debug connection" fails fast, and (b) a
+          # silent hang at "Waiting for VM Service port to be available" that never
+          # exits on its own — same wedged log-stream FD bug (flutter/flutter#116248),
+          # just surfacing as a stall instead of an error. A watchdog bounds each
+          # attempt so (b) gets caught and retried instead of burning the whole step
+          # timeout with no chance to retry. Anything else (compile error, test
+          # assertion, network) fails fast on attempt 1.
+          WATCHDOG_SECS=900  # comfortably above observed successful run times (~5-15m)
           attempts=0
           max_attempts=2
           while : ; do
             attempts=$((attempts + 1))
             log="$RUNNER_TEMP/flutter-test.attempt-$attempts.log"
+            watchdog_marker="$RUNNER_TEMP/watchdog-fired-$attempts"
+            rm -f "$watchdog_marker"
             set +e
-            flutter --verbose test integration_test/app_test.dart -d "$SIM_UDID" 2>&1 \
-              | tee "$log" "$RUNNER_TEMP/flutter-test.log"
-            status=${PIPESTATUS[0]}
+            flutter --verbose test integration_test/app_test.dart -d "$SIM_UDID" \
+              > >(tee "$log" "$RUNNER_TEMP/flutter-test.log") 2>&1 &
+            test_pid=$!
+            (
+              sleep "$WATCHDOG_SECS"
+              if kill -0 "$test_pid" 2>/dev/null; then
+                touch "$watchdog_marker"
+                echo "::warning title=flutter test watchdog::attempt $attempts exceeded $((WATCHDOG_SECS / 60))m with no exit (likely hung waiting for VM Service); killing"
+                kill -TERM "$test_pid" 2>/dev/null
+                sleep 10
+                kill -KILL "$test_pid" 2>/dev/null
+              fi
+            ) &
+            watchdog_pid=$!
+            wait "$test_pid"
+            status=$?
+            kill "$watchdog_pid" 2>/dev/null
+            wait "$watchdog_pid" 2>/dev/null
             set -e
             [ "$status" -eq 0 ] && break
             if [ "$attempts" -ge "$max_attempts" ]; then
               echo "::error title=flutter test failed::$attempts attempts; last exit $status"
               exit "$status"
             fi
-            if ! grep -q 'Error waiting for a debug connection' "$log"; then
+            if [ -f "$watchdog_marker" ]; then
+              echo "::warning title=flutter test retry::attempt $attempts hung waiting for VM Service; resetting sim and retrying"
+            elif grep -q 'Error waiting for a debug connection' "$log"; then
+              echo "::warning title=flutter test retry::debug-attach failure on attempt $attempts; resetting sim and retrying"
+            else
               echo "::error title=flutter test failed::non-retriable failure (exit $status)"
               exit "$status"
             fi
-            echo "::warning title=flutter test retry::debug-attach failure on attempt $attempts; resetting sim and retrying"
             # Reset the simulator to clear the host-side wedged `simctl spawn log
             # stream` file descriptor — the underlying Apple/CoreSimulator bug per
             # flutter/flutter#116248. Shutdown closes the FD; reboot leaves


### PR DESCRIPTION
## Summary
- The `ios` CI job's "Run iOS integration test" step has been hanging silently at `Waiting for VM Service port to be available...` with no error output, burning the full 25-minute step timeout before hard-failing (seen on runs [29538505917](https://github.com/embrace-io/embrace-flutter-sdk/actions/runs/29538505917/job/87755374042) and [29761172966](https://github.com/embrace-io/embrace-flutter-sdk/actions/runs/29761172966/job/88415872822))
- Root cause: Flutter discovers the Dart VM Service by parsing `simctl spawn log stream` output; when CoreSimulator's log stream silently stalls (same family of bug as flutter/flutter#116248, already referenced in this step's existing retry logic), Flutter has no internal timeout and hangs forever
- The existing sentinel-gated retry only fires on the explicit `Error waiting for a debug connection` error text — it never caught this failure mode since the process never actually exits, it just stalls
- Adds a bash-level watchdog (15 min) around the `flutter test` invocation using process substitution (instead of a plain pipe) so `wait` still captures Flutter's real exit code. A hang now gets killed and routed into the same simulator-reset-and-retry path already used for the debug-connection flake
- Bumps step timeout 25→38 min and job timeout 45→50 min to give two full watchdog cycles room
- Investigated whether a newer runner image would sidestep this instead — it wouldn't: macos-26 was already tried and reverted for a worse, Apple-confirmed hang (#323), and the same hang class is tracked as unresolved upstream on macos-15 too (actions/runner-images#13264, #12862)

## Test plan
- [ ] iOS CI job passes on this PR
- [ ] If a hang recurs, confirm the watchdog fires and the retry succeeds (check job logs for the `flutter test watchdog` warning annotation)