### PR TITLE
Revert embrace-android-sdk from 9.0.0 back to 8.4.0

### DIFF
--- a/embrace_android/android/gradle.properties
+++ b/embrace_android/android/gradle.properties
@@ -1,1 +1,1 @@
-emb_android_sdk=9.0.0
+emb_android_sdk=8.4.0

--- a/embrace_android/android/src/main/kotlin/io/embrace/flutter/EmbracePlugin.kt
+++ b/embrace_android/android/src/main/kotlin/io/embrace/flutter/EmbracePlugin.kt
@@ -11,7 +11,6 @@ import io.flutter.plugin.common.MethodChannel.MethodCallHandler
 import io.flutter.plugin.common.MethodChannel.Result
 
 import io.embrace.android.embracesdk.Embrace
-import io.embrace.android.embracesdk.PropertyScope
 import io.embrace.android.embracesdk.network.http.HttpMethod
 import io.embrace.android.embracesdk.internal.EmbraceInternalApi
 import io.embrace.android.embracesdk.internal.FlutterInternalInterface
@@ -570,8 +569,7 @@ public class EmbracePlugin : FlutterPlugin, MethodCallHandler {
         val value = call.getStringArgument(EmbraceConstants.VALUE_ARG_NAME)
         val permanent = call.getBooleanArgument(EmbraceConstants.PERMANENT_ARG_NAME)
         safeSdkCall {
-            val scope = if (permanent) PropertyScope.PERMANENT else PropertyScope.USER_SESSION
-            addUserSessionProperty(key, value, scope)
+            addSessionProperty(key, value, permanent)
         }
         result.success(null)
         return
@@ -580,7 +578,7 @@ public class EmbracePlugin : FlutterPlugin, MethodCallHandler {
     private fun handleRemoveSessionPropertyCall(call: MethodCall, result: Result) : Unit {
         val key = call.getStringArgument(EmbraceConstants.KEY_ARG_NAME)
         safeSdkCall {
-            removeUserSessionProperty(key)
+            removeSessionProperty(key)
         }
         result.success(null)
         return
@@ -589,7 +587,7 @@ public class EmbracePlugin : FlutterPlugin, MethodCallHandler {
     private fun handleEndSessionCall(call: MethodCall, result: Result) : Unit {
         val clearUserInfo = call.getBooleanArgument(EmbraceConstants.CLEAR_USER_INFO_ARG_NAME)
         safeSdkCall {
-            endUserSession()
+            endSession(clearUserInfo)
         }
         result.success(null)
         return
@@ -643,7 +641,7 @@ public class EmbracePlugin : FlutterPlugin, MethodCallHandler {
 
     private fun handleGetCurrentSessionIdCall(call: MethodCall, result: Result) {
         val currentSessionId = safeSdkCall {
-            currentUserSessionId
+            currentSessionId
         }
         result.success(currentSessionId)
     }

--- a/embrace_platform_interface/lib/method_channel_embrace.dart
+++ b/embrace_platform_interface/lib/method_channel_embrace.dart
@@ -122,7 +122,7 @@ class MethodChannelEmbrace extends EmbracePlatform {
 
   /// Minimum Embrace Android SDK version compatible with this version of
   /// the Embrace Flutter SDK
-  static const String minimumAndroidVersion = '9.0.0';
+  static const String minimumAndroidVersion = '8.4.0';
 
   /// The method channel used to interact with the native platform.
   @visibleForTesting


### PR DESCRIPTION
## Summary
- Reverts commit 9bed7cb, which bumped `embrace-android-sdk` from 8.4.0 to 9.0.0.
- Restores the pre-9.0.0 Android APIs (`addSessionProperty`, `removeSessionProperty`, `endSession`, `currentSessionId`) and `minimumAndroidVersion`.

## Test plan
- [x] Confirmed no commits since 9bed7cb touch the affected files
- [x] Confirmed no other code references the 9.0.0-only APIs being removed
- [x] Verified the reverted method calls exist in the actual embrace-android-sdk-8.4.0 AAR
- [x] `flutter analyze` and `flutter test` pass for embrace_platform_interface and embrace