### PR TITLE
Add screen-load span to EmbraceGoRouterObserver

### DIFF
--- a/embrace_go_router/lib/src/go_router_observer.dart
+++ b/embrace_go_router/lib/src/go_router_observer.dart
@@ -2,6 +2,8 @@ import 'package:embrace/embrace.dart';
 import 'package:embrace/embrace_api.dart';
 // ignore: implementation_imports
 import 'package:embrace/src/embrace_startup_tracker.dart';
+// ignore: implementation_imports
+import 'package:embrace/src/pointer_input_tracker.dart';
 import 'package:flutter/scheduler.dart';
 import 'package:flutter/widgets.dart';
 import 'package:go_router/go_router.dart';
@@ -55,6 +57,7 @@ class EmbraceGoRouterObserver extends NavigatorObserver {
   EmbraceGoRouterObserver({
     GoRouter? router,
     EmbraceRouteSettingsExtractor? routeSettingsExtractor,
+    this.screenLoadConfig = const EmbraceScreenLoadConfig(),
   })  : _router = router,
         routeSettingsExtractor = routeSettingsExtractor ?? _defaultExtractor {
     if (router != null) {
@@ -80,6 +83,9 @@ class EmbraceGoRouterObserver extends NavigatorObserver {
   /// specific route.
   final EmbraceRouteSettingsExtractor? routeSettingsExtractor;
 
+  /// Configuration for the screen-load span timing.
+  final EmbraceScreenLoadConfig screenLoadConfig;
+
   static RouteSettings? _defaultExtractor(Route<dynamic> route) {
     return route.settings;
   }
@@ -100,6 +106,7 @@ class EmbraceGoRouterObserver extends NavigatorObserver {
     _currentView = name;
     _initStateSpan(name);
     _startTtiSpan(name);
+    _startScreenLoadSpan(name);
   }
 
   void _initStateSpan(String initialRoute) {
@@ -146,6 +153,7 @@ class EmbraceGoRouterObserver extends NavigatorObserver {
     _currentView = name;
     _recordTransition(name);
     _startTtiSpan(name);
+    _startScreenLoadSpan(name);
   }
 
   /// Removes the listener from the [GoRouter] and stops the state span.
@@ -203,6 +211,43 @@ class EmbraceGoRouterObserver extends NavigatorObserver {
     SchedulerBinding.instance.scheduleFrame();
   }
 
+  void _startScreenLoadSpan(String routeName) {
+    final startTimeMs = EmbracePointerInputTracker.resolveStartTimeMs(
+      DateTime.now(),
+      screenLoadConfig.recencyThreshold,
+    );
+    int? endTimeMs;
+    EmbraceSpan? pendingSpan;
+
+    void tryStop() {
+      final span = pendingSpan;
+      final endMs = endTimeMs;
+      if (span != null && endMs != null) {
+        span.stop(endTimeMs: endMs);
+      }
+    }
+
+    Embrace.instance
+        .startSpan(
+      routeName,
+      startTimeMs: startTimeMs,
+    )
+        .then(
+      (span) {
+        pendingSpan = span;
+        span?.addAttribute('emb.type', 'view');
+        tryStop();
+      },
+      onError: (_, __) {},
+    );
+
+    SchedulerBinding.instance.addPostFrameCallback((_) {
+      endTimeMs = DateTime.now().millisecondsSinceEpoch;
+      tryStop();
+    });
+    SchedulerBinding.instance.scheduleFrame();
+  }
+
   void _updateView(Route<dynamic>? newRoute, Route<dynamic>? oldRoute) {
     if (oldRoute != null) {
       final settings = routeSettingsExtractor?.call(oldRoute);
@@ -227,6 +272,7 @@ class EmbraceGoRouterObserver extends NavigatorObserver {
     final routeName = routeSettingsExtractor?.call(route)?.name;
     if (routeName != null) {
       _startTtiSpan(routeName);
+      _startScreenLoadSpan(routeName);
     }
   }
 
@@ -238,6 +284,7 @@ class EmbraceGoRouterObserver extends NavigatorObserver {
         newRoute != null ? routeSettingsExtractor?.call(newRoute)?.name : null;
     if (routeName != null) {
       _startTtiSpan(routeName);
+      _startScreenLoadSpan(routeName);
     }
   }
 

--- a/embrace_go_router/test/go_router_observer_test.dart
+++ b/embrace_go_router/test/go_router_observer_test.dart
@@ -325,8 +325,7 @@ void main() {
             startTimeMs: any(named: 'startTimeMs'),
           ),
         ).called(1);
-        verify(() => screenLoadSpan.addAttribute('emb.type', 'view'))
-            .called(1);
+        verify(() => screenLoadSpan.addAttribute('emb.type', 'view')).called(1);
         verify(
           () => screenLoadSpan.stop(endTimeMs: any(named: 'endTimeMs')),
         ).called(1);
@@ -353,8 +352,7 @@ void main() {
             startTimeMs: any(named: 'startTimeMs'),
           ),
         ).called(1);
-        verify(() => screenLoadSpan.addAttribute('emb.type', 'view'))
-            .called(1);
+        verify(() => screenLoadSpan.addAttribute('emb.type', 'view')).called(1);
         verify(
           () => screenLoadSpan.stop(endTimeMs: any(named: 'endTimeMs')),
         ).called(1);

--- a/embrace_go_router/test/go_router_observer_test.dart
+++ b/embrace_go_router/test/go_router_observer_test.dart
@@ -120,6 +120,7 @@ void main() {
     group('TTI spans', () {
       late MockEmbrace mockEmbrace;
       late MockEmbraceSpan mockSpan;
+      late MockEmbraceSpan screenLoadSpanStub;
 
       setUpAll(() {
         registerFallbackValue('');
@@ -128,10 +129,22 @@ void main() {
       setUp(() {
         mockEmbrace = MockEmbrace();
         mockSpan = MockEmbraceSpan();
+        screenLoadSpanStub = MockEmbraceSpan();
         // ignore: invalid_use_of_visible_for_testing_member
         debugEmbraceOverride = mockEmbrace;
         when(() => mockEmbrace.startView(any())).thenAnswer((_) {});
         when(() => mockEmbrace.endView(any())).thenAnswer((_) {});
+        // didPush/didReplace also start a screen-load span (see the
+        // 'screen load spans' group below) — stub a catch-all for it here
+        // too so it doesn't throw, without affecting this group's TTI
+        // assertions. Registered before the exact TTI stub below, which
+        // overrides it for that specific call.
+        when(
+          () => mockEmbrace.startSpan(
+            any(),
+            startTimeMs: any(named: 'startTimeMs'),
+          ),
+        ).thenAnswer((_) => Future.value(screenLoadSpanStub));
         when(
           () => mockEmbrace.startSpan(
             'emb-time-to-interactive-flutter',
@@ -142,6 +155,11 @@ void main() {
             .thenAnswer((_) async => true);
         when(() => mockSpan.stop(endTimeMs: any(named: 'endTimeMs')))
             .thenAnswer((_) async => true);
+        when(() => screenLoadSpanStub.addAttribute(any(), any()))
+            .thenAnswer((_) async => true);
+        when(
+          () => screenLoadSpanStub.stop(endTimeMs: any(named: 'endTimeMs')),
+        ).thenAnswer((_) async => true);
       });
 
       tearDown(() {
@@ -242,12 +260,131 @@ void main() {
         verifyNever(() => mockEmbrace.startSpan(any()));
       });
     });
+
+    group('screen load spans', () {
+      late MockEmbrace mockEmbrace;
+      late MockEmbraceSpan screenLoadSpan;
+      late MockEmbraceSpan ttiSpan;
+
+      setUpAll(() {
+        registerFallbackValue('');
+      });
+
+      setUp(() {
+        mockEmbrace = MockEmbrace();
+        screenLoadSpan = MockEmbraceSpan();
+        ttiSpan = MockEmbraceSpan();
+        // ignore: invalid_use_of_visible_for_testing_member
+        debugEmbraceOverride = mockEmbrace;
+        when(() => mockEmbrace.startView(any())).thenAnswer((_) {});
+        when(() => mockEmbrace.endView(any())).thenAnswer((_) {});
+        // didPush/didReplace also start a TTI span (see the 'TTI spans'
+        // group above) — stub a catch-all for it here so it doesn't throw,
+        // without this group's tests needing to know its name. Each test
+        // below overrides this for the specific route name it exercises.
+        when(
+          () => mockEmbrace.startSpan(
+            any(),
+            startTimeMs: any(named: 'startTimeMs'),
+          ),
+        ).thenAnswer((_) => Future.value(ttiSpan));
+        when(() => ttiSpan.addAttribute(any(), any()))
+            .thenAnswer((_) async => true);
+        when(() => ttiSpan.stop(endTimeMs: any(named: 'endTimeMs')))
+            .thenAnswer((_) async => true);
+        when(() => screenLoadSpan.addAttribute(any(), any()))
+            .thenAnswer((_) async => true);
+        when(() => screenLoadSpan.stop(endTimeMs: any(named: 'endTimeMs')))
+            .thenAnswer((_) async => true);
+      });
+
+      void stubScreenLoadSpan(String routeName) {
+        when(
+          () => mockEmbrace.startSpan(
+            routeName,
+            startTimeMs: any(named: 'startTimeMs'),
+          ),
+        ).thenAnswer((_) => Future.value(screenLoadSpan));
+      }
+
+      tearDown(() {
+        // ignore: invalid_use_of_visible_for_testing_member
+        debugEmbraceOverride = null;
+      });
+
+      testWidgets('starts a span named after the route on push',
+          (tester) async {
+        stubScreenLoadSpan('/route');
+        final route = FakeRoute(const RouteSettings(name: '/route'));
+        observer.didPush(route, null);
+        await tester.pump();
+
+        verify(
+          () => mockEmbrace.startSpan(
+            '/route',
+            startTimeMs: any(named: 'startTimeMs'),
+          ),
+        ).called(1);
+        verify(() => screenLoadSpan.addAttribute('emb.type', 'view'))
+            .called(1);
+        verify(
+          () => screenLoadSpan.stop(endTimeMs: any(named: 'endTimeMs')),
+        ).called(1);
+      });
+
+      testWidgets('does not start a span when route name is null',
+          (tester) async {
+        final route = FakeRoute(const RouteSettings());
+        observer.didPush(route, null);
+        await tester.pump();
+
+        verifyNever(() => mockEmbrace.startSpan(any()));
+      });
+
+      testWidgets('starts a span on replace', (tester) async {
+        stubScreenLoadSpan('/new');
+        final newRoute = FakeRoute(const RouteSettings(name: '/new'));
+        observer.didReplace(newRoute: newRoute);
+        await tester.pump();
+
+        verify(
+          () => mockEmbrace.startSpan(
+            '/new',
+            startTimeMs: any(named: 'startTimeMs'),
+          ),
+        ).called(1);
+        verify(() => screenLoadSpan.addAttribute('emb.type', 'view'))
+            .called(1);
+        verify(
+          () => screenLoadSpan.stop(endTimeMs: any(named: 'endTimeMs')),
+        ).called(1);
+      });
+
+      testWidgets('does not start a span when newRoute is null on replace',
+          (tester) async {
+        final oldRoute = FakeRoute(const RouteSettings(name: '/old'));
+        observer.didReplace(oldRoute: oldRoute);
+        await tester.pump();
+
+        verifyNever(() => mockEmbrace.startSpan(any()));
+      });
+
+      testWidgets('does not start a span on pop', (tester) async {
+        final route = FakeRoute(const RouteSettings(name: '/route'));
+        final previousRoute = FakeRoute(const RouteSettings(name: '/previous'));
+        observer.didPop(route, previousRoute);
+        await tester.pump();
+
+        verifyNever(() => mockEmbrace.startSpan(any()));
+      });
+    });
   });
 
   group('delegate mode (router provided)', () {
     late MockEmbrace mockEmbrace;
     late MockEmbraceSpan mockStateSpan;
     late MockEmbraceSpan mockTtiSpan;
+    late MockEmbraceSpan screenLoadSpanStub;
 
     setUpAll(() {
       registerFallbackValue('');
@@ -258,8 +395,25 @@ void main() {
       mockEmbrace = MockEmbrace();
       mockStateSpan = MockEmbraceSpan();
       mockTtiSpan = MockEmbraceSpan();
+      screenLoadSpanStub = MockEmbraceSpan();
       // ignore: invalid_use_of_visible_for_testing_member
       debugEmbraceOverride = mockEmbrace;
+      // The initial route report and every route change also start a
+      // screen-load span (see the 'screen load spans' group below) — stub a
+      // catch-all for it here so 'state span'/'TTI spans' tests don't throw
+      // on the unstubbed call. Registered first, since mocktail resolves
+      // overlapping stubs by last-registered-wins and both the state-span
+      // and TTI-span stubs below need to take precedence for their exact
+      // span names (an unqualified `startSpan(...)` call always has its
+      // omitted `parent` argument defaulted to null on both the role and
+      // real invocation, so this catch-all would otherwise also match those
+      // exact-name calls).
+      when(
+        () => mockEmbrace.startSpan(
+          any(),
+          startTimeMs: any(named: 'startTimeMs'),
+        ),
+      ).thenAnswer((_) => Future.value(screenLoadSpanStub));
       when(
         () => mockEmbrace.startSpan('emb-state-screen-flutter-automatic'),
       ).thenAnswer((_) => Future.value(mockStateSpan));
@@ -282,6 +436,11 @@ void main() {
           .thenAnswer((_) async => true);
       when(() => mockTtiSpan.stop(endTimeMs: any(named: 'endTimeMs')))
           .thenAnswer((_) async => true);
+      when(() => screenLoadSpanStub.addAttribute(any(), any()))
+          .thenAnswer((_) async => true);
+      when(
+        () => screenLoadSpanStub.stop(endTimeMs: any(named: 'endTimeMs')),
+      ).thenAnswer((_) async => true);
     });
 
     tearDown(() {
@@ -462,6 +621,91 @@ void main() {
           ),
         ).called(1);
         verifyNever(() => mockTtiSpan.addAttribute('route', '/home'));
+      });
+    });
+
+    group('screen load spans', () {
+      testWidgets('starts a screen-load span for the initial route',
+          (tester) async {
+        final router = _buildRouter();
+        await tester.pumpWidget(MaterialApp.router(routerConfig: router));
+        EmbraceGoRouterObserver(router: router);
+        await tester.pump();
+
+        verify(
+          () => mockEmbrace.startSpan(
+            '/',
+            startTimeMs: any(named: 'startTimeMs'),
+          ),
+        ).called(1);
+        verify(() => screenLoadSpanStub.addAttribute('emb.type', 'view'))
+            .called(1);
+        verify(
+          () => screenLoadSpanStub.stop(endTimeMs: any(named: 'endTimeMs')),
+        ).called(1);
+      });
+
+      testWidgets('starts a new screen-load span on each route change',
+          (tester) async {
+        final router = _buildRouter();
+        await tester.pumpWidget(MaterialApp.router(routerConfig: router));
+        final obs = EmbraceGoRouterObserver(router: router);
+        addTearDown(obs.dispose);
+        await tester.pump();
+
+        router.go('/home');
+        await tester.pump();
+
+        verify(
+          () => mockEmbrace.startSpan(
+            '/home',
+            startTimeMs: any(named: 'startTimeMs'),
+          ),
+        ).called(1);
+      });
+
+      testWidgets('does not start a duplicate span for the same route',
+          (tester) async {
+        final router = _buildRouter();
+        await tester.pumpWidget(MaterialApp.router(routerConfig: router));
+        final obs = EmbraceGoRouterObserver(router: router);
+        addTearDown(obs.dispose);
+        await tester.pump();
+
+        router.go('/home');
+        await tester.pump();
+        router.go('/home');
+        await tester.pump();
+
+        verify(
+          () => mockEmbrace.startSpan(
+            '/home',
+            startTimeMs: any(named: 'startTimeMs'),
+          ),
+        ).called(1);
+      });
+
+      testWidgets('does not start a span on NavigatorObserver callbacks',
+          (tester) async {
+        final router = _buildRouter();
+        await tester.pumpWidget(MaterialApp.router(routerConfig: router));
+        final obs = EmbraceGoRouterObserver(router: router);
+        addTearDown(obs.dispose);
+        await tester.pump();
+
+        obs
+          ..didPush(FakeRoute(const RouteSettings(name: '/other')), null)
+          ..didPop(FakeRoute(const RouteSettings(name: '/other')), null)
+          ..didReplace(
+            newRoute: FakeRoute(const RouteSettings(name: '/other')),
+          );
+
+        verifyNever(
+          () => mockEmbrace.startSpan(
+            '/other',
+            startTimeMs: any(named: 'startTimeMs'),
+          ),
+        );
       });
     });
   });


### PR DESCRIPTION
## Summary
- Adds a screen-load span (timed from last user touch to first frame) to `EmbraceGoRouterObserver`, matching the base `EmbraceNavigationObserver` behavior added in #327.
- Covers both NavigatorObserver mode and delegate mode.
- Reuses `EmbracePointerInputTracker`/`EmbraceScreenLoadConfig` from `embrace`.

EMBR-12644

## Test plan
- [x] `flutter analyze` clean
- [x] `flutter test` — 35 tests pass, including new "screen load spans" groups for both modes