### PR TITLE
Release v4.9.0

### DIFF
--- a/embrace/CHANGELOG.md
+++ b/embrace/CHANGELOG.md
@@ -1,7 +1,12 @@
+# 4.9.0
+
+* Added a screen-load span to `EmbraceNavigationObserver`, timed from the last user touch to the first frame of the new route
+* Bug fixes
+* Updated Embrace iOS SDK to 6.21.0
+
 # 4.8.0
 
 * Version bump
-* Added a screen-load span to `EmbraceNavigationObserver`, timed from the last user touch to the first frame of the new route
 
 # 4.7.0
 

--- a/embrace/pubspec.yaml
+++ b/embrace/pubspec.yaml
@@ -1,6 +1,6 @@
 name: embrace
 description: A comprehensive observability and monitoring platform for iOS and Android apps built with Flutter.
-version: 4.8.0
+version: 4.9.0
 homepage: https://embrace.io
 environment:
   sdk: ">=3.0.0 <4.0.0"
@@ -14,9 +14,9 @@ flutter:
         default_package: embrace_ios
 dependencies:
   dartastic_opentelemetry_api: 1.0.0-beta.9
-  embrace_android: ">=4.8.0 <4.9.0"
-  embrace_ios: ">=4.8.0 <4.9.0"
-  embrace_platform_interface: ">=4.8.0 <4.9.0"
+  embrace_android: ">=4.9.0 <4.10.0"
+  embrace_ios: ">=4.9.0 <4.10.0"
+  embrace_platform_interface: ">=4.9.0 <4.10.0"
   flutter:
     sdk: flutter
   http: ">=0.13.3 <2.0.0"

--- a/embrace_android/CHANGELOG.md
+++ b/embrace_android/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 4.9.0
+
+* Version bump
+
 # 4.8.0
 
 * Updated Embrace Android SDK to 8.4.0

--- a/embrace_android/pubspec.yaml
+++ b/embrace_android/pubspec.yaml
@@ -1,6 +1,6 @@
 name: embrace_android
 description: Android implementation of the embrace plugin as defined by the embrace_platform_interface package.
-version: 4.8.0
+version: 4.9.0
 homepage: https://embrace.io
 environment:
   sdk: ">=3.0.0 <4.0.0"
@@ -14,7 +14,7 @@ flutter:
         pluginClass: EmbracePlugin
         dartPluginClass: EmbraceAndroid
 dependencies:
-  embrace_platform_interface: ">=4.8.0 <4.9.0"
+  embrace_platform_interface: ">=4.9.0 <4.10.0"
   flutter:
     sdk: flutter
 dev_dependencies:

--- a/embrace_dio/CHANGELOG.md
+++ b/embrace_dio/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 4.9.0
+
+* Version bump
+
 # 4.8.0
 
 * Version bump

--- a/embrace_dio/pubspec.yaml
+++ b/embrace_dio/pubspec.yaml
@@ -16,7 +16,7 @@ dependencies:
   plugin_platform_interface: ^2.1.0
   embrace_platform_interface: ">=4.9.0 <4.10.0"
 dev_dependencies:
-  dartastic_opentelemetry_api: 1.0.0-beta.7
+  dartastic_opentelemetry_api: 1.0.0-beta.9
   flutter_test:
     sdk: flutter
   mocktail: ^1.0.4

--- a/embrace_dio/pubspec.yaml
+++ b/embrace_dio/pubspec.yaml
@@ -1,6 +1,6 @@
 name: embrace_dio
 description: Allows automatic Dio network capture when using the the embrace plugin.
-version: 4.8.0
+version: 4.9.0
 homepage: https://embrace.io
 environment:
   sdk: ">=3.0.0 <4.0.0"
@@ -9,12 +9,12 @@ dependencies:
   build_runner: ^2.0.0
   build_version: ^2.0.0
   dio: '>=4.0.0 <6.0.0'
-  embrace: ^4.8.0
+  embrace: ^4.9.0
   flutter:
     sdk: flutter
   platform: ^3.1.0
   plugin_platform_interface: ^2.1.0
-  embrace_platform_interface: ">=4.8.0 <4.9.0"
+  embrace_platform_interface: ">=4.9.0 <4.10.0"
 dev_dependencies:
   dartastic_opentelemetry_api: 1.0.0-beta.7
   flutter_test:

--- a/embrace_go_router/CHANGELOG.md
+++ b/embrace_go_router/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 4.9.0
+
+* Added a screen-load span to `EmbraceGoRouterObserver`, timed from the last user touch to the first frame of the new route
+* Bug fixes
+
 # 4.8.0
 
 * Version bump

--- a/embrace_go_router/pubspec.yaml
+++ b/embrace_go_router/pubspec.yaml
@@ -1,17 +1,17 @@
 name: embrace_go_router
 description: Provides go_router navigation tracking for the Embrace SDK.
-version: 4.8.0
+version: 4.9.0
 homepage: https://embrace.io
 environment:
   sdk: ">=3.0.0 <4.0.0"
   flutter: ">=3.10.0"
 dependencies:
-  embrace: ^4.8.0
+  embrace: ^4.9.0
   flutter:
     sdk: flutter
   go_router: ">=6.0.0 <16.0.0"
 dev_dependencies:
-  embrace_platform_interface: ">=4.8.0 <4.9.0"
+  embrace_platform_interface: ">=4.9.0 <4.10.0"
   flutter_test:
     sdk: flutter
   mocktail: ">=0.3.0 <2.0.0"

--- a/embrace_ios/CHANGELOG.md
+++ b/embrace_ios/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 4.9.0
+
+* Added Swift Package Manager support
+* Updated Embrace iOS SDK to 6.21.0
+
 # 4.8.0
 
 * Version bump

--- a/embrace_ios/pubspec.yaml
+++ b/embrace_ios/pubspec.yaml
@@ -1,6 +1,6 @@
 name: embrace_ios
 description: iOS implementation of the embrace plugin as defined by the embrace_platform_interface package.
-version: 4.8.0
+version: 4.9.0
 homepage: https://embrace.io
 environment:
   sdk: ">=3.0.0 <4.0.0"
@@ -13,7 +13,7 @@ flutter:
         pluginClass: EmbracePlugin
         dartPluginClass: EmbraceIOS
 dependencies:
-  embrace_platform_interface: ">=4.8.0 <4.9.0"
+  embrace_platform_interface: ">=4.9.0 <4.10.0"
   flutter:
     sdk: flutter
 dev_dependencies:

--- a/embrace_platform_interface/CHANGELOG.md
+++ b/embrace_platform_interface/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 4.9.0
+
+* Version bump
+
 # 4.8.0
 
 * Updated minimum required Embrace Android SDK to 8.4.0

--- a/embrace_platform_interface/lib/src/version.dart
+++ b/embrace_platform_interface/lib/src/version.dart
@@ -1,2 +1,2 @@
 // Generated code. Do not modify.
-const packageVersion = '4.8.0';
+const packageVersion = '4.9.0';

--- a/embrace_platform_interface/pubspec.yaml
+++ b/embrace_platform_interface/pubspec.yaml
@@ -1,6 +1,6 @@
 name: embrace_platform_interface
 description: A common platform interface for the Embrace plugin that enables platform-specific implementations.
-version: 4.8.0
+version: 4.9.0
 homepage: https://embrace.io
 environment:
   sdk: ">=3.0.0 <4.0.0"


### PR DESCRIPTION
## Summary
- Version bump to 4.9.0 across all 6 packages (embrace, embrace_platform_interface, embrace_android, embrace_ios, embrace_dio, embrace_go_router)
- Updated CHANGELOG.md for each package

## Test plan
- [x] `./verify_versions.sh` passes
- [x] Manual build/run on iOS device
- [x] Manual build/run on Android emulator