### PR TITLE
feat(flutter): add slow frame detection

### DIFF
--- a/embrace/lib/embrace.dart
+++ b/embrace/lib/embrace.dart
@@ -4,6 +4,7 @@ import 'dart:ui';
 import 'package:dartastic_opentelemetry_api/dartastic_opentelemetry_api.dart'
     hide Severity;
 import 'package:embrace/embrace_api.dart';
+import 'package:embrace/src/embrace_frame_detector.dart';
 import 'package:embrace/src/embrace_startup_tracker.dart';
 import 'package:embrace/src/otel/otel.dart';
 import 'package:embrace/src/pointer_input_tracker.dart';
@@ -566,6 +567,8 @@ Future<void> _start(
   await EmbracePlatform.instance.attachToHostSdk(
     enableIntegrationTesting: enableIntegrationTesting,
   );
+
+  EmbraceFrameDetector().start();
 
   if (action != null) {
     await _installErrorHandlers(action);

--- a/embrace/lib/src/embrace_frame_detector.dart
+++ b/embrace/lib/src/embrace_frame_detector.dart
@@ -1,0 +1,80 @@
+import 'package:embrace_platform_interface/embrace_platform_interface.dart';
+import 'package:flutter/scheduler.dart';
+import 'package:meta/meta.dart';
+
+EmbraceFrameDetector? _activeDetector;
+
+@internal
+// Called by EmbraceNavigationObserver when the active route changes.
+void updateCurrentRoute(String? route) {
+  _activeDetector?.currentRoute = route;
+}
+
+@internal
+class EmbraceFrameDetectionConfig {
+  const EmbraceFrameDetectionConfig({
+    this.slowFrameThresholdMs = 16,
+    this.slowFrameBatchSize = 60,
+  });
+
+  final int slowFrameThresholdMs;
+  final int slowFrameBatchSize;
+}
+
+@internal
+class EmbraceFrameDetector {
+  EmbraceFrameDetector({EmbraceFrameDetectionConfig? config})
+      : _config = config ?? const EmbraceFrameDetectionConfig();
+
+  final EmbraceFrameDetectionConfig _config;
+  int _slowFrameCount = 0;
+  int _worstSlowBuildMs = 0;
+  int _worstSlowRasterMs = 0;
+  String? currentRoute;
+
+  void start() {
+    _activeDetector = this;
+    SchedulerBinding.instance.addTimingsCallback(_onTimings);
+  }
+
+  void stop() {
+    if (_activeDetector == this) _activeDetector = null;
+    SchedulerBinding.instance.removeTimingsCallback(_onTimings);
+  }
+
+  @visibleForTesting
+  void handleTimings(List<FrameTiming> timings) => _onTimings(timings);
+
+  void _onTimings(List<FrameTiming> timings) {
+    for (final timing in timings) {
+      final buildMs = timing.buildDuration.inMilliseconds;
+      final rasterMs = timing.rasterDuration.inMilliseconds;
+
+      if (buildMs > _config.slowFrameThresholdMs ||
+          rasterMs > _config.slowFrameThresholdMs) {
+        _slowFrameCount++;
+        if (buildMs > _worstSlowBuildMs) _worstSlowBuildMs = buildMs;
+        if (rasterMs > _worstSlowRasterMs) _worstSlowRasterMs = rasterMs;
+
+        if (_slowFrameCount >= _config.slowFrameBatchSize) {
+          _flushSlowFrames();
+        }
+      }
+    }
+  }
+
+  void _flushSlowFrames() {
+    EmbracePlatform.instance.logInfo(
+      'slow-frames',
+      {
+        'count': '$_slowFrameCount',
+        'worst_build_ms': '$_worstSlowBuildMs',
+        'worst_raster_ms': '$_worstSlowRasterMs',
+        if (currentRoute != null) 'route': currentRoute!,
+      },
+    );
+    _slowFrameCount = 0;
+    _worstSlowBuildMs = 0;
+    _worstSlowRasterMs = 0;
+  }
+}

--- a/embrace/lib/src/navigation_observer.dart
+++ b/embrace/lib/src/navigation_observer.dart
@@ -1,5 +1,6 @@
 import 'package:embrace/embrace.dart';
 import 'package:embrace/embrace_api.dart';
+import 'package:embrace/src/embrace_frame_detector.dart';
 import 'package:embrace/src/embrace_startup_tracker.dart';
 import 'package:embrace/src/pointer_input_tracker.dart';
 import 'package:flutter/material.dart';
@@ -171,6 +172,7 @@ class EmbraceNavigationObserver extends RouteObserver<ModalRoute<dynamic>> {
       final name = settings?.name;
       if (name != null) {
         Embrace.instance.startView(name);
+        updateCurrentRoute(name);
       }
     }
   }

--- a/embrace/test/src/embrace_frame_detector_test.dart
+++ b/embrace/test/src/embrace_frame_detector_test.dart
@@ -1,0 +1,207 @@
+import 'dart:ui';
+
+import 'package:embrace/src/embrace_frame_detector.dart';
+import 'package:embrace_platform_interface/embrace_platform_interface.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:plugin_platform_interface/plugin_platform_interface.dart';
+
+class _MockEmbracePlatform extends Mock
+    with MockPlatformInterfaceMixin
+    implements EmbracePlatform {}
+
+// Builds a FrameTiming with the given build and raster durations in ms.
+FrameTiming _frameTiming({int buildMs = 0, int rasterMs = 0}) {
+  return FrameTiming(
+    vsyncStart: 0,
+    buildStart: 0,
+    buildFinish: buildMs * 1000,
+    rasterStart: 0,
+    rasterFinish: rasterMs * 1000,
+    rasterFinishWallTime: 0,
+  );
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late _MockEmbracePlatform platform;
+  late EmbraceFrameDetector detector;
+
+  setUp(() {
+    platform = _MockEmbracePlatform();
+    EmbracePlatform.instance = platform;
+    detector = EmbraceFrameDetector();
+  });
+
+  group('EmbraceFrameDetectionConfig', () {
+    test('has expected defaults', () {
+      const config = EmbraceFrameDetectionConfig();
+      expect(config.slowFrameThresholdMs, 16);
+      expect(config.slowFrameBatchSize, 60);
+    });
+
+    test('accepts custom values', () {
+      const config = EmbraceFrameDetectionConfig(
+        slowFrameThresholdMs: 8,
+        slowFrameBatchSize: 10,
+      );
+      expect(config.slowFrameThresholdMs, 8);
+      expect(config.slowFrameBatchSize, 10);
+    });
+  });
+
+  group('EmbraceFrameDetector', () {
+    group('normal frames', () {
+      test('does not report frames at or below slow threshold', () {
+        detector.handleTimings([_frameTiming(buildMs: 16)]);
+        verifyNever(() => platform.logInfo(any(), any()));
+      });
+    });
+
+    group('slow frames', () {
+      test('does not report before batch size is reached', () {
+        detector.handleTimings([_frameTiming(buildMs: 17)]);
+        verifyNever(() => platform.logInfo(any(), any()));
+      });
+
+      test('reports slow-frames log when batch size is reached', () {
+        detector = EmbraceFrameDetector(
+          config: const EmbraceFrameDetectionConfig(slowFrameBatchSize: 3),
+        )
+          ..handleTimings([_frameTiming(buildMs: 20)])
+          ..handleTimings([_frameTiming(buildMs: 30)])
+          ..handleTimings([_frameTiming(buildMs: 25)]);
+
+        verify(
+          () => platform.logInfo('slow-frames', {
+            'count': '3',
+            'worst_build_ms': '30',
+            'worst_raster_ms': '0',
+          }),
+        ).called(1);
+      });
+
+      test('resets count and worst timings after flush', () {
+        detector = EmbraceFrameDetector(
+          config: const EmbraceFrameDetectionConfig(slowFrameBatchSize: 2),
+        )
+          // First batch.
+          ..handleTimings([_frameTiming(buildMs: 50)])
+          ..handleTimings([_frameTiming(buildMs: 60)])
+          // Second batch — worst should reset.
+          ..handleTimings([_frameTiming(buildMs: 20)])
+          ..handleTimings([_frameTiming(buildMs: 25)]);
+
+        verifyInOrder([
+          () => platform.logInfo('slow-frames', {
+                'count': '2',
+                'worst_build_ms': '60',
+                'worst_raster_ms': '0',
+              }),
+          () => platform.logInfo('slow-frames', {
+                'count': '2',
+                'worst_build_ms': '25',
+                'worst_raster_ms': '0',
+              }),
+        ]);
+      });
+
+      test('tracks worst raster duration across batch', () {
+        detector = EmbraceFrameDetector(
+          config: const EmbraceFrameDetectionConfig(slowFrameBatchSize: 2),
+        )
+          ..handleTimings([_frameTiming(rasterMs: 50)])
+          ..handleTimings([_frameTiming(rasterMs: 20)]);
+
+        verify(
+          () => platform.logInfo('slow-frames', {
+            'count': '2',
+            'worst_build_ms': '0',
+            'worst_raster_ms': '50',
+          }),
+        ).called(1);
+      });
+
+      test('triggers on raster duration exceeding threshold', () {
+        detector = EmbraceFrameDetector(
+          config: const EmbraceFrameDetectionConfig(slowFrameBatchSize: 1),
+        )..handleTimings([_frameTiming(rasterMs: 17)]);
+
+        verify(
+          () => platform.logInfo('slow-frames', {
+            'count': '1',
+            'worst_build_ms': '0',
+            'worst_raster_ms': '17',
+          }),
+        ).called(1);
+      });
+    });
+
+    group('route correlation', () {
+      test('includes route in slow-frames log when route is set', () {
+        detector = EmbraceFrameDetector(
+          config: const EmbraceFrameDetectionConfig(slowFrameBatchSize: 1),
+        )
+          ..currentRoute = '/home'
+          ..handleTimings([_frameTiming(buildMs: 20)]);
+
+        verify(
+          () => platform.logInfo('slow-frames', {
+            'count': '1',
+            'worst_build_ms': '20',
+            'worst_raster_ms': '0',
+            'route': '/home',
+          }),
+        ).called(1);
+      });
+
+      test('omits route key when no route has been set', () {
+        detector = EmbraceFrameDetector(
+          config: const EmbraceFrameDetectionConfig(slowFrameBatchSize: 1),
+        )..handleTimings([_frameTiming(buildMs: 20)]);
+
+        verify(
+          () => platform.logInfo('slow-frames', {
+            'count': '1',
+            'worst_build_ms': '20',
+            'worst_raster_ms': '0',
+          }),
+        ).called(1);
+      });
+
+      test('updates route between batches', () {
+        detector = EmbraceFrameDetector(
+          config: const EmbraceFrameDetectionConfig(slowFrameBatchSize: 1),
+        )
+          ..currentRoute = '/first'
+          ..handleTimings([_frameTiming(buildMs: 20)])
+          ..currentRoute = '/second'
+          ..handleTimings([_frameTiming(buildMs: 20)]);
+
+        verifyInOrder([
+          () => platform.logInfo('slow-frames', {
+                'count': '1',
+                'worst_build_ms': '20',
+                'worst_raster_ms': '0',
+                'route': '/first',
+              }),
+          () => platform.logInfo('slow-frames', {
+                'count': '1',
+                'worst_build_ms': '20',
+                'worst_raster_ms': '0',
+                'route': '/second',
+              }),
+        ]);
+      });
+    });
+
+    group('stop', () {
+      test('stop does not throw', () {
+        detector
+          ..start()
+          ..stop();
+      });
+    });
+  });
+}


### PR DESCRIPTION
## What
Adds `EmbraceFrameDetector`, which listens to `SchedulerBinding.instance.addTimingsCallback` and reports slow frames (build or raster duration > 16ms, configurable). Slow frames are batched — a `slow-frames` log is flushed every `slowFrameBatchSize` (default 60) occurrences, carrying the count and worst-case build/raster timings rather than logging every individual frame. The active navigation route is tracked via `updateCurrentRoute` (wired from `EmbraceNavigationObserver`) and included on each flushed log so slow-frame reports can be correlated with the screen they occurred on.

Thresholds and batch size live in `EmbraceFrameDetectionConfig`, following the same const-config pattern as `EmbraceSpanProcessorConfig`.

## Why
The native Android/iOS SDKs have no visibility into Flutter's widget build or raster thread — this is purely a Flutter-layer concern. This maps to the Core Mobile Vitals **Smoothness** metric.

## Context on the split
This was originally combined with frozen-frame detection (>=700ms) in #258, which stalled — partly on a transient CI failure (an otel dependency bump, fixed separately in #259) and partly on review feedback that the PR bundled two different concerns without enough context. Splitting it here: this PR is slow-frame detection only, mapping to Smoothness. Frozen-frame detection (Responsiveness/Freeze) is a separate ticket, EMBR-13651, and is stacked on top of this branch in a follow-up PR so it doesn't need to re-review this same route-correlation plumbing.

## Test plan
- [x] `flutter test test/src/embrace_frame_detector_test.dart` — all passing
- [x] `flutter analyze` — no issues