### PR TITLE
feat(flutter): add frozen frame detection

### DIFF
--- a/embrace/lib/src/embrace_frame_detector.dart
+++ b/embrace/lib/src/embrace_frame_detector.dart
@@ -14,10 +14,12 @@ void updateCurrentRoute(String? route) {
 class EmbraceFrameDetectionConfig {
   const EmbraceFrameDetectionConfig({
     this.slowFrameThresholdMs = 16,
+    this.frozenFrameThresholdMs = 700,
     this.slowFrameBatchSize = 60,
   });
 
   final int slowFrameThresholdMs;
+  final int frozenFrameThresholdMs;
   final int slowFrameBatchSize;
 }
 
@@ -50,7 +52,17 @@ class EmbraceFrameDetector {
       final buildMs = timing.buildDuration.inMilliseconds;
       final rasterMs = timing.rasterDuration.inMilliseconds;
 
-      if (buildMs > _config.slowFrameThresholdMs ||
+      if (buildMs >= _config.frozenFrameThresholdMs ||
+          rasterMs >= _config.frozenFrameThresholdMs) {
+        EmbracePlatform.instance.logWarning(
+          'frozen-frame',
+          {
+            'build_ms': '$buildMs',
+            'raster_ms': '$rasterMs',
+            if (currentRoute != null) 'route': currentRoute!,
+          },
+        );
+      } else if (buildMs > _config.slowFrameThresholdMs ||
           rasterMs > _config.slowFrameThresholdMs) {
         _slowFrameCount++;
         if (buildMs > _worstSlowBuildMs) _worstSlowBuildMs = buildMs;

--- a/embrace/test/src/embrace_frame_detector_test.dart
+++ b/embrace/test/src/embrace_frame_detector_test.dart
@@ -38,15 +38,18 @@ void main() {
     test('has expected defaults', () {
       const config = EmbraceFrameDetectionConfig();
       expect(config.slowFrameThresholdMs, 16);
+      expect(config.frozenFrameThresholdMs, 700);
       expect(config.slowFrameBatchSize, 60);
     });
 
     test('accepts custom values', () {
       const config = EmbraceFrameDetectionConfig(
         slowFrameThresholdMs: 8,
+        frozenFrameThresholdMs: 500,
         slowFrameBatchSize: 10,
       );
       expect(config.slowFrameThresholdMs, 8);
+      expect(config.frozenFrameThresholdMs, 500);
       expect(config.slowFrameBatchSize, 10);
     });
   });
@@ -55,6 +58,7 @@ void main() {
     group('normal frames', () {
       test('does not report frames at or below slow threshold', () {
         detector.handleTimings([_frameTiming(buildMs: 16)]);
+        verifyNever(() => platform.logWarning(any(), any()));
         verifyNever(() => platform.logInfo(any(), any()));
       });
     });
@@ -138,6 +142,71 @@ void main() {
       });
     });
 
+    group('frozen frames', () {
+      test('reports logWarning immediately for frozen build duration', () {
+        detector.handleTimings([_frameTiming(buildMs: 701)]);
+
+        verify(
+          () => platform.logWarning(
+            'frozen-frame',
+            {'build_ms': '701', 'raster_ms': '0'},
+          ),
+        ).called(1);
+      });
+
+      test('reports logWarning for frame at exactly frozen threshold', () {
+        detector.handleTimings([_frameTiming(buildMs: 700)]);
+
+        verify(
+          () => platform.logWarning(
+            'frozen-frame',
+            {'build_ms': '700', 'raster_ms': '0'},
+          ),
+        ).called(1);
+      });
+
+      test('reports logWarning immediately for frozen raster duration', () {
+        detector.handleTimings([_frameTiming(rasterMs: 701)]);
+
+        verify(
+          () => platform.logWarning(
+            'frozen-frame',
+            {'build_ms': '0', 'raster_ms': '701'},
+          ),
+        ).called(1);
+      });
+
+      test('does not count frozen frames as slow frames', () {
+        detector = EmbraceFrameDetector(
+          config: const EmbraceFrameDetectionConfig(slowFrameBatchSize: 1),
+        )..handleTimings([_frameTiming(buildMs: 701)]);
+
+        verifyNever(() => platform.logInfo(any(), any()));
+      });
+
+      test('reports each frozen frame independently', () {
+        detector
+          ..handleTimings([_frameTiming(buildMs: 800)])
+          ..handleTimings([_frameTiming(buildMs: 900)]);
+
+        verify(() => platform.logWarning('frozen-frame', any())).called(2);
+      });
+    });
+
+    group('mixed frames in a single batch', () {
+      test('handles slow and frozen frames in the same callback', () {
+        detector = EmbraceFrameDetector(
+          config: const EmbraceFrameDetectionConfig(slowFrameBatchSize: 1),
+        )..handleTimings([
+            _frameTiming(buildMs: 20),
+            _frameTiming(buildMs: 800),
+          ]);
+
+        verify(() => platform.logInfo('slow-frames', any())).called(1);
+        verify(() => platform.logWarning('frozen-frame', any())).called(1);
+      });
+    });
+
     group('route correlation', () {
       test('includes route in slow-frames log when route is set', () {
         detector = EmbraceFrameDetector(
@@ -153,6 +222,19 @@ void main() {
             'worst_raster_ms': '0',
             'route': '/home',
           }),
+        ).called(1);
+      });
+
+      test('includes route in frozen-frame log when route is set', () {
+        detector
+          ..currentRoute = '/detail'
+          ..handleTimings([_frameTiming(buildMs: 800)]);
+
+        verify(
+          () => platform.logWarning(
+            'frozen-frame',
+            {'build_ms': '800', 'raster_ms': '0', 'route': '/detail'},
+          ),
         ).called(1);
       });
 


### PR DESCRIPTION
## Stacked on #349
This branches off `ben.bennett/feat/EMBR-11467-slow-frame-detection` (#349) so the diff here only shows the frozen-frame addition, not the shared route-correlation plumbing. Base should be retargeted to `main` once #349 merges.

## What
Extends `EmbraceFrameDetector` (added in #349) to also detect frozen frames — build or raster duration >= 700ms (configurable via `EmbraceFrameDetectionConfig.frozenFrameThresholdMs`). Unlike slow frames, frozen frames are reported immediately as a `frozen-frame` warning log (not batched), since a single freeze is independently actionable. The active route is included when set. A frozen frame is never also counted toward the slow-frame batch.

## Why
Per the Core Mobile Vitals spec, a >=700ms frame block maps to the **Responsiveness (Freeze)** vital — the Flutter equivalent of Android's Frozen Frame / iOS Hang classification — which is distinct from the Smoothness metric that slow-frame detection (#349) covers. This was originally bundled with slow-frame detection in #258; splitting it into its own ticket/PR here.

## Out of scope
Freeze Duration tracking and a Severe-Freeze severity tier are called for by the master Responsiveness spec but are not implemented here — tracked as separate follow-up work.

## Test plan
- [x] `flutter test test/src/embrace_frame_detector_test.dart` — all passing (19 tests, including the new frozen-frame and mixed-batch cases)
- [x] `flutter analyze` — no issues