### PR TITLE
Add Embrace.disable() / SDK shutdown lifecycle

### DIFF
--- a/embrace/lib/embrace.dart
+++ b/embrace/lib/embrace.dart
@@ -99,6 +99,14 @@ class Embrace implements EmbraceFlutterApi {
   }
 
   @override
+  void disable() {
+    _runCatching('disable', () {
+      stopActiveFrameDetector();
+      _platform.disable();
+    });
+  }
+
+  @override
   void addBreadcrumb(String message) {
     _runCatching('addBreadcrumb', () => _platform.addBreadcrumb(message));
   }

--- a/embrace/lib/embrace_api.dart
+++ b/embrace/lib/embrace_api.dart
@@ -47,6 +47,13 @@ abstract class EmbraceFlutterApi implements EmbraceApi {
   /// ```
   Future<void> installErrorHandlers(FutureOr<void> Function() action);
 
+  /// Stops the Embrace SDK from capturing and generating any further data.
+  ///
+  /// This also tears down the Dart-side background monitors started by
+  /// [start] (such as frame drop detection). The SDK cannot be restarted
+  /// after this call.
+  void disable();
+
   /// Manually logs a Dart error or exception to Embrace. You should use this
   /// if you want to capture errors/exceptions and report them to Embrace.
   /// A good example would be to call this function from within a try-catch

--- a/embrace/lib/src/embrace_frame_detector.dart
+++ b/embrace/lib/src/embrace_frame_detector.dart
@@ -11,6 +11,12 @@ void updateCurrentRoute(String? route) {
 }
 
 @internal
+// Called by Embrace.disable() to tear down frame detection.
+void stopActiveFrameDetector() {
+  _activeDetector?.stop();
+}
+
+@internal
 class EmbraceFrameDetectionConfig {
   const EmbraceFrameDetectionConfig({
     this.slowFrameThresholdMs = 16,

--- a/embrace/test/embrace_test.dart
+++ b/embrace/test/embrace_test.dart
@@ -967,6 +967,24 @@ void main() {
       });
     });
 
+    group('disable', () {
+      test('disables the platform implementation', () {
+        Embrace.instance.disable();
+        verify(() => embracePlatform.disable()).called(1);
+      });
+
+      test(
+          'logs internal error when platform implementation '
+          'throws an error', () {
+        when(() => embracePlatform.disable()).thenThrow(MockError());
+        Embrace.instance.disable();
+
+        verify(
+          () => embracePlatform.logInternalError('disable', errorMessage),
+        ).called(1);
+      });
+    });
+
     group('getDeviceId', () {
       test('returns device ID when platform implementation exists', () async {
         const platformName = '__test_platform__';

--- a/embrace/test/src/embrace_frame_detector_test.dart
+++ b/embrace/test/src/embrace_frame_detector_test.dart
@@ -285,5 +285,22 @@ void main() {
           ..stop();
       });
     });
+
+    group('stopActiveFrameDetector', () {
+      test('does nothing when no detector is active', () {
+        expect(stopActiveFrameDetector, returnsNormally);
+      });
+
+      test('stops the active detector', () {
+        detector.start();
+        updateCurrentRoute('/before');
+        expect(detector.currentRoute, '/before');
+
+        stopActiveFrameDetector();
+        updateCurrentRoute('/after');
+
+        expect(detector.currentRoute, '/before');
+      });
+    });
   });
 }

--- a/embrace_android/android/src/main/kotlin/io/embrace/flutter/EmbracePlugin.kt
+++ b/embrace_android/android/src/main/kotlin/io/embrace/flutter/EmbracePlugin.kt
@@ -34,6 +34,7 @@ internal object EmbraceConstants {
 
     // Method Names
     internal const val ATTACH_SDK_METHOD_NAME : String = "attachToHostSdk"
+    internal const val DISABLE_METHOD_NAME : String = "disable"
     internal const val ADD_BREADCRUMB_METHOD_NAME : String = "addBreadcrumb"
     internal const val LOG_INFO_METHOD_NAME : String = "logInfo"
     internal const val LOG_WARNING_METHOD_NAME : String = "logWarning"
@@ -155,6 +156,7 @@ public class EmbracePlugin : FlutterPlugin, MethodCallHandler {
         try {
             when (call.method) {
                 EmbraceConstants.ATTACH_SDK_METHOD_NAME -> handleAttachSdkCall(call, result)
+                EmbraceConstants.DISABLE_METHOD_NAME -> handleDisableCall(call, result)
                 EmbraceConstants.ADD_BREADCRUMB_METHOD_NAME -> handleAddBreadcrumbCall(call, result)
                 EmbraceConstants.LOG_INFO_METHOD_NAME -> handleLogInfoCall(call, result)
                 EmbraceConstants.LOG_WARNING_METHOD_NAME -> handleLogWarningCall(call, result)
@@ -306,6 +308,14 @@ public class EmbracePlugin : FlutterPlugin, MethodCallHandler {
         // required by Flutter, and passing any Flutter-specific data down to the
         // Android SDK.
         result.success(started)
+        return
+    }
+
+    private fun handleDisableCall(call: MethodCall, result: Result) : Unit {
+        safeSdkCall {
+            disable()
+        }
+        result.success(null)
         return
     }
 

--- a/embrace_ios/ios/embrace_ios/Sources/embrace_ios/EmbracePlugin.swift
+++ b/embrace_ios/ios/embrace_ios/Sources/embrace_ios/EmbracePlugin.swift
@@ -9,6 +9,7 @@ public class EmbracePlugin: NSObject, FlutterPlugin {
 
     // Method Names
     static let AttachSdkMethodName = "attachToHostSdk"
+    static let DisableMethodName = "disable"
     static let AddBreadcrumbMethodName = "addBreadcrumb"
     static let LogPushNotificationMethodName = "logPushNotification"
     static let LogInfoMethodName = "logInfo"
@@ -131,6 +132,8 @@ public class EmbracePlugin: NSObject, FlutterPlugin {
         switch call.method {
             case EmbracePlugin.AttachSdkMethodName:
                 handleAttachSdkCall(call, result: result)
+            case EmbracePlugin.DisableMethodName:
+                handleDisableCall(call, result: result)
             case EmbracePlugin.AddBreadcrumbMethodName:
                 handleAddBreadcrumbCall(call, result: result)
             case EmbracePlugin.LogPushNotificationMethodName:
@@ -234,6 +237,13 @@ public class EmbracePlugin: NSObject, FlutterPlugin {
         // required by Flutter, and passing any Flutter-specific data down to the
         // iOS SDK.
         result(NSNumber(value: started))
+    }
+
+    private func handleDisableCall(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
+        callAppleSdk { client in
+            try? client.stop()
+        }
+        result(nil)
     }
 
     private func handleAddBreadcrumbCall(_ call: FlutterMethodCall, result: @escaping FlutterResult) {

--- a/embrace_platform_interface/lib/embrace_platform_interface.dart
+++ b/embrace_platform_interface/lib/embrace_platform_interface.dart
@@ -75,6 +75,15 @@ abstract class EmbracePlatform extends PlatformInterface {
     throw UnimplementedError('attachToHostSdk() has not been implemented.');
   }
 
+  /// Stops the Embrace SDK from capturing and generating any further data.
+  ///
+  /// On iOS this calls the native SDK's `stop()`. On Android this calls the
+  /// native SDK's `disable()`, which also clears any cached data that has
+  /// not yet been exported. The SDK cannot be restarted after this call.
+  void disable() {
+    throw UnimplementedError('disable() has not been implemented.');
+  }
+
   /// Logs a breadcrumb.
   void logBreadcrumb(String message) {
     throw UnimplementedError('logBreadcrumb(String) has not been implemented');

--- a/embrace_platform_interface/lib/method_channel_embrace.dart
+++ b/embrace_platform_interface/lib/method_channel_embrace.dart
@@ -19,6 +19,7 @@ class MethodChannelEmbrace extends EmbracePlatform {
 
   // Method Names
   static const String _attachSdkMethodName = 'attachToHostSdk';
+  static const String _disableMethodName = 'disable';
   static const String _addBreadcrumbMethodName = 'addBreadcrumb';
   static const String _logPushNotificationMethodName = 'logPushNotification';
   static const String _startViewMethodName = 'startView';
@@ -710,6 +711,13 @@ class MethodChannelEmbrace extends EmbracePlatform {
       _headersArgName: headers,
       _timeoutSecondsArgName: timeoutSeconds,
     });
+  }
+
+  @override
+  void disable() {
+    throwIfNotStarted();
+    methodChannel.invokeMethod(_disableMethodName);
+    _isStarted = false;
   }
 
   /// Throws a [StateError] if the SDK has not been started.

--- a/embrace_platform_interface/test/src/method_channel_embrace_test.dart
+++ b/embrace_platform_interface/test/src/method_channel_embrace_test.dart
@@ -873,6 +873,29 @@ void main() {
       });
     });
 
+    group('disable', () {
+      test('invokes disable method in the method channel', () async {
+        await methodChannelEmbrace.attachToHostSdk(
+          enableIntegrationTesting: false,
+        );
+        methodChannelEmbrace.disable();
+        expect(log, contains(isMethodCall('disable', arguments: null)));
+      });
+
+      test('marks the SDK as no longer started', () async {
+        await methodChannelEmbrace.attachToHostSdk(
+          enableIntegrationTesting: false,
+        );
+        methodChannelEmbrace.disable();
+        expect(methodChannelEmbrace.isStarted, isFalse);
+      });
+
+      test('throws StateError if not started', () {
+        expect(methodChannelEmbrace.disable, throwsA(isA<StateError>()));
+        expect(log, isEmpty);
+      });
+    });
+
     group('endSession', () {
       test('invokes endSession method in the method channel', () async {
         await methodChannelEmbrace.attachToHostSdk(


### PR DESCRIPTION
## Summary
- Adds `Embrace.instance.disable()` across the Dart public API, platform interface, and both native plugin bridges — the SDK previously had no supported way to stop capturing data or tear down Dart-side background monitors once started.
- On iOS this calls the native SDK's `Embrace.client.stop()`; on Android it calls the native SDK's `disable()`. This mirrors the Unity SDK's own `Embrace.Instance.Disable()`, which already unifies these two calls under one cross-platform name.
- `Embrace.disable()` also stops the active `EmbraceFrameDetector` (slow/frozen frame detection) via a new `stopActiveFrameDetector()` hook, giving its previously-unused `stop()` method a real production caller.
- `MethodChannelEmbrace.disable()` marks the SDK as no longer started, consistent with both native SDKs documenting that the SDK cannot be restarted after being stopped/disabled.

## Context
Filed as EMBR-13677 after discovering, while implementing EMBR-12643 (Dart UI Isolate Hang Detection), that its "shuts down cleanly when the SDK is stopped" acceptance criterion had no production code path to exercise — there was no `Embrace.stop()`/`disable()` anywhere in this SDK. Once EMBR-12643 merges, its `EmbraceHangDetector.stop()` should be wired into `disable()` the same way `EmbraceFrameDetector` is here.

## Test plan
- [x] `flutter test` passes in `embrace` (269 tests) and `embrace_platform_interface` (142 tests)
- [x] `flutter analyze` clean in both packages
- [ ] Native Android/iOS bridge changes have no existing unit test infrastructure in this repo (matches the rest of `EmbracePlugin.kt`/`.swift`) — reviewed by hand against the `attachToHostSdk`/`endSession` patterns they mirror