### PR TITLE
ci: pin pana job's Flutter version

### DIFF
--- a/.github/workflows/embrace.yaml
+++ b/.github/workflows/embrace.yaml
@@ -438,6 +438,7 @@ jobs:
         uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2
         with:
           channel: stable
+          flutter-version: ${{ env.FLUTTER_VERSION }}
           cache: true
       - name: ⬇️ Pub Get
         run: flutter pub get


### PR DESCRIPTION
## Summary
- The `pana` job's Flutter setup step only pinned `channel: stable` (no `flutter-version`), unlike every other job in this workflow, which pins `flutter-version: ${{ env.FLUTTER_VERSION }}`.
- Flutter's `stable` channel advanced to a newer release since the last green run on `main`, and that release's analyzer emits a `DotShorthandPropertyAccess` AST node that the job's hardcoded `--dartdoc-version 8.3.4` doesn't implement a visitor for, crashing `dartdoc` and dropping the pana score below the required 70.
- This isn't specific to any one PR — it broke the very first CI run after the last successful push to `main`, so it would affect any PR or push right now.
- Fix: pin the job to the same `FLUTTER_VERSION` (`3.44.6`) the other jobs already use, so it stops floating with `stable`.

## Test plan
- [x] YAML validated for syntax
- [ ] CI on this PR should show `pana` passing again