### PR TITLE
Add Dart UI isolate hang detection

### DIFF
--- a/embrace/lib/embrace.dart
+++ b/embrace/lib/embrace.dart
@@ -103,6 +103,7 @@ class Embrace implements EmbraceFlutterApi {
   void disable() {
     _runCatching('disable', () {
       stopActiveFrameDetector();
+      stopActiveHangDetector();
       _platform.disable();
     });
   }

--- a/embrace/lib/embrace.dart
+++ b/embrace/lib/embrace.dart
@@ -5,6 +5,7 @@ import 'package:dartastic_opentelemetry_api/dartastic_opentelemetry_api.dart'
     hide Severity;
 import 'package:embrace/embrace_api.dart';
 import 'package:embrace/src/embrace_frame_detector.dart';
+import 'package:embrace/src/embrace_hang_detector.dart';
 import 'package:embrace/src/embrace_startup_tracker.dart';
 import 'package:embrace/src/otel/otel.dart';
 import 'package:embrace/src/pointer_input_tracker.dart';
@@ -577,6 +578,7 @@ Future<void> _start(
   );
 
   EmbraceFrameDetector().start();
+  await EmbraceHangDetector().start();
 
   if (action != null) {
     await _installErrorHandlers(action);

--- a/embrace/lib/src/embrace_hang_detector.dart
+++ b/embrace/lib/src/embrace_hang_detector.dart
@@ -142,8 +142,7 @@ class EmbraceHangDetector with WidgetsBindingObserver {
 
     final mainReceivePort = ReceivePort()..listen(_handleMonitorMessage);
     final errorPort = ReceivePort()..listen(_handleMonitorError);
-    final exitPort = ReceivePort()
-      ..listen((_) => _closeErrorAndExitPorts());
+    final exitPort = ReceivePort()..listen((_) => _closeErrorAndExitPorts());
 
     final isolate = await Isolate.spawn(
       _monitorEntryPoint,

--- a/embrace/lib/src/embrace_hang_detector.dart
+++ b/embrace/lib/src/embrace_hang_detector.dart
@@ -1,16 +1,154 @@
+import 'dart:async';
+import 'dart:isolate';
+
+import 'package:embrace_platform_interface/embrace_platform_interface.dart';
+
 /// Configuration for the Dart UI isolate hang detector's ping interval and
 /// hang threshold.
 class EmbraceHangDetectionConfig {
   /// Creates a hang-detection configuration.
   const EmbraceHangDetectionConfig({
-    this.pingInterval = const Duration(milliseconds: 1000),
+    this.pingInterval = const Duration(milliseconds: 200),
     this.hangThreshold = const Duration(milliseconds: 700),
   });
 
-  /// How often the monitor isolate pings the main isolate.
+  /// How often the monitor isolate pings the main isolate. Should be
+  /// meaningfully smaller than [hangThreshold] so a hang's start can be
+  /// detected with reasonable precision.
   final Duration pingInterval;
 
   /// How long the main isolate can go without echoing a ping before it's
   /// considered hung.
   final Duration hangThreshold;
+}
+
+/// Tracks whether the main isolate has stopped echoing pings, independent of
+/// the isolate/timer plumbing that drives it — so the detection logic can be
+/// exercised directly in tests.
+class EmbraceHangTracker {
+  /// Creates a tracker that considers the main isolate hung once
+  /// [hangThreshold] has elapsed since the last echo. [initialGoodTime]
+  /// seeds the last-known-responsive time, defaulting to now.
+  EmbraceHangTracker(this.hangThreshold, {DateTime? initialGoodTime})
+      : _lastGoodTime = initialGoodTime ?? DateTime.now();
+
+  /// How long the main isolate can go without echoing a ping before it's
+  /// considered hung.
+  final Duration hangThreshold;
+
+  DateTime _lastGoodTime;
+  DateTime? _hangStartTime;
+
+  /// Call on every ping tick, before sending the ping, to check whether
+  /// [now] has crossed [hangThreshold] since the last echo.
+  void onTick(DateTime now) {
+    if (_hangStartTime == null &&
+        now.difference(_lastGoodTime) >= hangThreshold) {
+      _hangStartTime = _lastGoodTime;
+    }
+  }
+
+  /// Call when an echo is received at [now]. Returns the resolved hang
+  /// window if a hang was in progress, or `null` if the main isolate was
+  /// already responsive.
+  ({DateTime start, DateTime end})? onEcho(DateTime now) {
+    final hangStart = _hangStartTime;
+    _hangStartTime = null;
+    _lastGoodTime = now;
+    if (hangStart == null) return null;
+    return (start: hangStart, end: now);
+  }
+}
+
+/// Detects when the main (UI) Dart isolate stops responding.
+///
+/// Flutter's UI thread is a Dart isolate, not the platform's native main
+/// thread, so iOS watchdog kills and Android ANR detection never see a
+/// frozen Dart event loop. This class spawns a background isolate that
+/// pings the main isolate on a fixed interval; if the main isolate doesn't
+/// echo a ping within [EmbraceHangDetectionConfig.hangThreshold], the time
+/// until it next responds is recorded as a hang.
+class EmbraceHangDetector {
+  /// Creates a hang detector using [config], or the default configuration
+  /// if none is given.
+  EmbraceHangDetector({EmbraceHangDetectionConfig? config})
+      : _config = config ?? const EmbraceHangDetectionConfig();
+
+  final EmbraceHangDetectionConfig _config;
+
+  ReceivePort? _mainReceivePort;
+  Isolate? _monitorIsolate;
+  SendPort? _monitorSendPort;
+
+  /// Spawns the monitor isolate and begins pinging the main isolate.
+  Future<void> start() async {
+    final mainReceivePort = ReceivePort();
+    _mainReceivePort = mainReceivePort;
+    mainReceivePort.listen(_handleMonitorMessage);
+
+    _monitorIsolate = await Isolate.spawn(
+      _monitorEntryPoint,
+      [
+        mainReceivePort.sendPort,
+        _config.pingInterval.inMilliseconds,
+        _config.hangThreshold.inMilliseconds,
+      ],
+    );
+  }
+
+  /// Kills the monitor isolate and stops listening for its messages.
+  void stop() {
+    _monitorIsolate?.kill(priority: Isolate.immediate);
+    _monitorIsolate = null;
+    _mainReceivePort?.close();
+    _mainReceivePort = null;
+    _monitorSendPort = null;
+  }
+
+  void _handleMonitorMessage(dynamic message) {
+    if (message is SendPort) {
+      _monitorSendPort = message;
+    } else if (message is int) {
+      _monitorSendPort?.send(message);
+    } else if (message is List) {
+      _recordHang(message[0] as int, message[1] as int);
+    }
+  }
+
+  Future<bool> _recordHang(int startTimeMs, int endTimeMs) {
+    return EmbracePlatform.instance.recordCompletedSpan(
+      'emb-dart-isolate-hang',
+      startTimeMs,
+      endTimeMs,
+      attributes: {'duration_ms': (endTimeMs - startTimeMs).toString()},
+    );
+  }
+}
+
+void _monitorEntryPoint(List<dynamic> args) {
+  final mainSendPort = args[0] as SendPort;
+  final pingInterval = Duration(milliseconds: args[1] as int);
+  final hangThreshold = Duration(milliseconds: args[2] as int);
+
+  final monitorReceivePort = ReceivePort();
+  mainSendPort.send(monitorReceivePort.sendPort);
+
+  final tracker = EmbraceHangTracker(hangThreshold);
+
+  monitorReceivePort.listen((dynamic message) {
+    if (message is! int) return;
+    final resolved = tracker.onEcho(DateTime.now());
+    if (resolved != null) {
+      mainSendPort.send([
+        resolved.start.millisecondsSinceEpoch,
+        resolved.end.millisecondsSinceEpoch,
+      ]);
+    }
+  });
+
+  Timer.periodic(pingInterval, (_) {
+    final now = DateTime.now();
+    tracker.onTick(now);
+    mainSendPort.send(now.millisecondsSinceEpoch);
+  });
 }

--- a/embrace/lib/src/embrace_hang_detector.dart
+++ b/embrace/lib/src/embrace_hang_detector.dart
@@ -2,7 +2,7 @@ import 'dart:async';
 import 'dart:isolate';
 
 import 'package:embrace_platform_interface/embrace_platform_interface.dart';
-import 'package:meta/meta.dart';
+import 'package:flutter/widgets.dart';
 
 /// Configuration for the Dart UI isolate hang detector's ping interval and
 /// hang threshold.
@@ -69,7 +69,12 @@ class EmbraceHangTracker {
 /// pings the main isolate on a fixed interval; if the main isolate doesn't
 /// echo a ping within [EmbraceHangDetectionConfig.hangThreshold], the time
 /// until it next responds is recorded as a hang.
-class EmbraceHangDetector {
+///
+/// Monitoring pauses while the app is backgrounded and restarts fresh on
+/// foreground, since the OS may suspend the process while backgrounded —
+/// without this, resuming would otherwise look like an isolate hang lasting
+/// the entire time in the background.
+class EmbraceHangDetector with WidgetsBindingObserver {
   /// Creates a hang detector using [config], or the default configuration
   /// if none is given.
   EmbraceHangDetector({EmbraceHangDetectionConfig? config})
@@ -83,21 +88,53 @@ class EmbraceHangDetector {
   Isolate? _monitorIsolate;
   SendPort? _monitorSendPort;
 
-  /// Spawns the monitor isolate and begins pinging the main isolate.
+  /// Bumped by every [_startMonitoring]/[_stopMonitoring] call so an
+  /// in-flight isolate spawn can detect that a later start/stop superseded
+  /// it — e.g. a background/foreground flip landing while `Isolate.spawn`
+  /// is still resolving — and discard itself instead of overwriting the
+  /// newer state.
+  int _monitoringGeneration = 0;
+
+  /// Spawns the monitor isolate, begins pinging the main isolate, and starts
+  /// observing app lifecycle changes so monitoring can pause while
+  /// backgrounded.
   Future<void> start() async {
-    final mainReceivePort = ReceivePort();
-    _mainReceivePort = mainReceivePort;
-    mainReceivePort.listen(_handleMonitorMessage);
+    WidgetsBinding.instance.addObserver(this);
+    await _startMonitoring();
+  }
 
-    final errorPort = ReceivePort();
-    _errorPort = errorPort;
-    errorPort.listen(_handleMonitorError);
+  /// Kills the monitor isolate, stops listening for its messages, and stops
+  /// observing app lifecycle changes.
+  void stop() {
+    WidgetsBinding.instance.removeObserver(this);
+    _stopMonitoring();
+  }
 
-    final exitPort = ReceivePort();
-    _exitPort = exitPort;
-    exitPort.listen((_) => _closeErrorAndExitPorts());
+  @override
+  void didChangeAppLifecycleState(AppLifecycleState state) {
+    switch (state) {
+      case AppLifecycleState.paused:
+        _stopMonitoring();
+      case AppLifecycleState.resumed:
+        if (_monitorIsolate == null) {
+          unawaited(_startMonitoring());
+        }
+      case AppLifecycleState.inactive:
+      case AppLifecycleState.hidden:
+      case AppLifecycleState.detached:
+        break;
+    }
+  }
 
-    _monitorIsolate = await Isolate.spawn(
+  Future<void> _startMonitoring() async {
+    final generation = ++_monitoringGeneration;
+
+    final mainReceivePort = ReceivePort()..listen(_handleMonitorMessage);
+    final errorPort = ReceivePort()..listen(_handleMonitorError);
+    final exitPort = ReceivePort()
+      ..listen((_) => _closeErrorAndExitPorts());
+
+    final isolate = await Isolate.spawn(
       _monitorEntryPoint,
       [
         mainReceivePort.sendPort,
@@ -107,10 +144,26 @@ class EmbraceHangDetector {
       onError: errorPort.sendPort,
       onExit: exitPort.sendPort,
     );
+
+    if (generation != _monitoringGeneration) {
+      // A stop (or a newer start) happened while this isolate was
+      // spawning. It was never published, so tear it down rather than
+      // adopting it over the newer state.
+      isolate.kill(priority: Isolate.immediate);
+      mainReceivePort.close();
+      errorPort.close();
+      exitPort.close();
+      return;
+    }
+
+    _mainReceivePort = mainReceivePort;
+    _errorPort = errorPort;
+    _exitPort = exitPort;
+    _monitorIsolate = isolate;
   }
 
-  /// Kills the monitor isolate and stops listening for its messages.
-  void stop() {
+  void _stopMonitoring() {
+    _monitoringGeneration++;
     _monitorIsolate?.kill(priority: Isolate.immediate);
     _monitorIsolate = null;
     _mainReceivePort?.close();
@@ -118,6 +171,11 @@ class EmbraceHangDetector {
     _monitorSendPort = null;
     _closeErrorAndExitPorts();
   }
+
+  /// Whether the monitor isolate is currently running. Exposed for testing
+  /// the pause/resume behavior around app lifecycle changes.
+  @visibleForTesting
+  bool get isMonitoring => _monitorIsolate != null;
 
   void _closeErrorAndExitPorts() {
     _errorPort?.close();

--- a/embrace/lib/src/embrace_hang_detector.dart
+++ b/embrace/lib/src/embrace_hang_detector.dart
@@ -17,7 +17,7 @@ void stopActiveHangDetector() {
 class EmbraceHangDetectionConfig {
   /// Creates a hang-detection configuration.
   const EmbraceHangDetectionConfig({
-    this.tickInterval = const Duration(milliseconds: 200),
+    this.tickInterval = const Duration(milliseconds: 100),
     this.hangThreshold = const Duration(milliseconds: 700),
   });
 

--- a/embrace/lib/src/embrace_hang_detector.dart
+++ b/embrace/lib/src/embrace_hang_detector.dart
@@ -1,5 +1,4 @@
 import 'dart:async';
-import 'dart:isolate';
 
 import 'package:embrace_platform_interface/embrace_platform_interface.dart';
 import 'package:flutter/widgets.dart';
@@ -13,71 +12,62 @@ void stopActiveHangDetector() {
   _activeDetector?.stop();
 }
 
-/// Configuration for the Dart UI isolate hang detector's ping interval and
+/// Configuration for the Dart UI isolate hang detector's tick interval and
 /// hang threshold.
 class EmbraceHangDetectionConfig {
   /// Creates a hang-detection configuration.
   const EmbraceHangDetectionConfig({
-    this.pingInterval = const Duration(milliseconds: 200),
+    this.tickInterval = const Duration(milliseconds: 200),
     this.hangThreshold = const Duration(milliseconds: 700),
   });
 
-  /// How often the monitor isolate pings the main isolate. Should be
+  /// How often the detector's timer ticks on the main isolate. Should be
   /// meaningfully smaller than [hangThreshold] so a hang's start can be
   /// detected with reasonable precision.
-  final Duration pingInterval;
+  final Duration tickInterval;
 
-  /// How long the main isolate can go without echoing a ping before it's
-  /// considered hung.
+  /// How long the main isolate's event loop can go without processing a
+  /// scheduled tick before it's considered hung.
   final Duration hangThreshold;
 }
 
-/// Tracks whether the main isolate has stopped echoing pings, independent of
-/// the isolate/timer plumbing that drives it — so the detection logic can be
+/// Tracks whether the main isolate's event loop has stalled, independent of
+/// the timer plumbing that drives it — so the detection logic can be
 /// exercised directly in tests.
 class EmbraceHangTracker {
   /// Creates a tracker that considers the main isolate hung once
-  /// [hangThreshold] has elapsed since the last echo. [initialGoodTime]
+  /// [hangThreshold] has elapsed since the last tick. [initialGoodTime]
   /// seeds the last-known-responsive time, defaulting to now.
   EmbraceHangTracker(this.hangThreshold, {DateTime? initialGoodTime})
       : _lastGoodTime = initialGoodTime ?? DateTime.now();
 
-  /// How long the main isolate can go without echoing a ping before it's
-  /// considered hung.
+  /// How long the main isolate's event loop can go without processing a
+  /// scheduled tick before it's considered hung.
   final Duration hangThreshold;
 
   DateTime _lastGoodTime;
-  DateTime? _hangStartTime;
 
-  /// Call on every ping tick, before sending the ping, to check whether
-  /// [now] has crossed [hangThreshold] since the last echo.
-  void onTick(DateTime now) {
-    if (_hangStartTime == null &&
-        now.difference(_lastGoodTime) >= hangThreshold) {
-      _hangStartTime = _lastGoodTime;
-    }
-  }
-
-  /// Call when an echo is received at [now]. Returns the resolved hang
-  /// window if a hang was in progress, or `null` if the main isolate was
-  /// already responsive.
-  ({DateTime start, DateTime end})? onEcho(DateTime now) {
-    final hangStart = _hangStartTime;
-    _hangStartTime = null;
+  /// Call every time the timer ticks, with the current time. A timer tick
+  /// firing at all proves the event loop just ran, so a gap since the last
+  /// tick that crosses [hangThreshold] means the event loop was stalled for
+  /// that whole gap. Returns the resolved hang window if one is found, or
+  /// `null` if [now] is within [hangThreshold] of the last tick.
+  ({DateTime start, DateTime end})? onTick(DateTime now) {
+    final lastGoodTime = _lastGoodTime;
     _lastGoodTime = now;
-    if (hangStart == null) return null;
-    return (start: hangStart, end: now);
+    if (now.difference(lastGoodTime) < hangThreshold) return null;
+    return (start: lastGoodTime, end: now);
   }
 }
 
-/// Detects when the main (UI) Dart isolate stops responding.
+/// Detects when the main (UI) Dart isolate's event loop stalls.
 ///
 /// Flutter's UI thread is a Dart isolate, not the platform's native main
 /// thread, so iOS watchdog kills and Android ANR detection never see a
-/// frozen Dart event loop. This class spawns a background isolate that
-/// pings the main isolate on a fixed interval; if the main isolate doesn't
-/// echo a ping within [EmbraceHangDetectionConfig.hangThreshold], the time
-/// until it next responds is recorded as a hang.
+/// frozen Dart event loop. This class runs a periodic timer directly on the
+/// main isolate; a timer tick firing late — more than
+/// [EmbraceHangDetectionConfig.hangThreshold] after the previous one — means
+/// the event loop was stalled for that gap, which is recorded as a hang.
 ///
 /// Monitoring pauses while the app is backgrounded and restarts fresh on
 /// foreground, since the OS may suspend the process while backgrounded —
@@ -91,30 +81,18 @@ class EmbraceHangDetector with WidgetsBindingObserver {
 
   final EmbraceHangDetectionConfig _config;
 
-  ReceivePort? _mainReceivePort;
-  ReceivePort? _errorPort;
-  ReceivePort? _exitPort;
-  Isolate? _monitorIsolate;
-  SendPort? _monitorSendPort;
+  EmbraceHangTracker? _tracker;
+  Timer? _tickTimer;
 
-  /// Bumped by every [_startMonitoring]/[_stopMonitoring] call so an
-  /// in-flight isolate spawn can detect that a later start/stop superseded
-  /// it — e.g. a background/foreground flip landing while `Isolate.spawn`
-  /// is still resolving — and discard itself instead of overwriting the
-  /// newer state.
-  int _monitoringGeneration = 0;
-
-  /// Spawns the monitor isolate, begins pinging the main isolate, and starts
-  /// observing app lifecycle changes so monitoring can pause while
-  /// backgrounded.
+  /// Begins the periodic tick timer and starts observing app lifecycle
+  /// changes so monitoring can pause while backgrounded.
   Future<void> start() async {
     _activeDetector = this;
     WidgetsBinding.instance.addObserver(this);
-    await _startMonitoring();
+    _startMonitoring();
   }
 
-  /// Kills the monitor isolate, stops listening for its messages, and stops
-  /// observing app lifecycle changes.
+  /// Stops the tick timer and stops observing app lifecycle changes.
   void stop() {
     if (_activeDetector == this) _activeDetector = null;
     WidgetsBinding.instance.removeObserver(this);
@@ -127,9 +105,7 @@ class EmbraceHangDetector with WidgetsBindingObserver {
       case AppLifecycleState.paused:
         _stopMonitoring();
       case AppLifecycleState.resumed:
-        if (_monitorIsolate == null) {
-          unawaited(_startMonitoring());
-        }
+        if (_tickTimer == null) _startMonitoring();
       case AppLifecycleState.inactive:
       case AppLifecycleState.hidden:
       case AppLifecycleState.detached:
@@ -137,98 +113,39 @@ class EmbraceHangDetector with WidgetsBindingObserver {
     }
   }
 
-  Future<void> _startMonitoring() async {
-    final generation = ++_monitoringGeneration;
-
-    final mainReceivePort = ReceivePort()..listen(_handleMonitorMessage);
-    final errorPort = ReceivePort()..listen(_handleMonitorError);
-    final exitPort = ReceivePort()..listen((_) => _closeErrorAndExitPorts());
-
-    final isolate = await Isolate.spawn(
-      _monitorEntryPoint,
-      [
-        mainReceivePort.sendPort,
-        _config.pingInterval.inMilliseconds,
-        _config.hangThreshold.inMilliseconds,
-      ],
-      onError: errorPort.sendPort,
-      onExit: exitPort.sendPort,
+  void _startMonitoring() {
+    _tracker = EmbraceHangTracker(_config.hangThreshold);
+    _tickTimer = Timer.periodic(
+      _config.tickInterval,
+      (_) => _handleTick(DateTime.now()),
     );
-
-    if (generation != _monitoringGeneration) {
-      // A stop (or a newer start) happened while this isolate was
-      // spawning. It was never published, so tear it down rather than
-      // adopting it over the newer state.
-      isolate.kill(priority: Isolate.immediate);
-      mainReceivePort.close();
-      errorPort.close();
-      exitPort.close();
-      return;
-    }
-
-    _mainReceivePort = mainReceivePort;
-    _errorPort = errorPort;
-    _exitPort = exitPort;
-    _monitorIsolate = isolate;
   }
 
   void _stopMonitoring() {
-    _monitoringGeneration++;
-    _monitorIsolate?.kill(priority: Isolate.immediate);
-    _monitorIsolate = null;
-    _mainReceivePort?.close();
-    _mainReceivePort = null;
-    _monitorSendPort = null;
-    _closeErrorAndExitPorts();
+    _tickTimer?.cancel();
+    _tickTimer = null;
+    _tracker = null;
   }
 
-  /// Whether the monitor isolate is currently running. Exposed for testing
-  /// the pause/resume behavior around app lifecycle changes.
+  /// Whether the tick timer is currently running. Exposed for testing the
+  /// pause/resume behavior around app lifecycle changes.
   @visibleForTesting
-  bool get isMonitoring => _monitorIsolate != null;
+  bool get isMonitoring => _tickTimer != null;
 
-  void _closeErrorAndExitPorts() {
-    _errorPort?.close();
-    _errorPort = null;
-    _exitPort?.close();
-    _exitPort = null;
-  }
-
-  /// Handles an uncaught error from the monitor isolate as if it had
-  /// arrived over the real error port. Exposed for testing error forwarding
-  /// without spawning a real isolate.
+  /// Handles a timer tick as if it had fired at [now]. Exposed for testing
+  /// the reporting mechanism without waiting on a real timer.
   @visibleForTesting
-  void handleMonitorError(dynamic message) => _handleMonitorError(message);
+  void handleTick(DateTime now) => _handleTick(now);
 
-  void _handleMonitorError(dynamic message) {
-    _closeErrorAndExitPorts();
-
-    final params = message as List<dynamic>;
-    final error = params[0] as String;
-    final stackTrace = params[1] as String;
-    EmbracePlatform.instance.logDartError(
-      stackTrace,
-      error,
-      "Uncaught error in the Dart UI isolate hang detector's monitor "
-      'isolate',
-      null,
-      errorType: 'IsolateUncaughtError',
-    );
-  }
-
-  /// Handles a message from the monitor isolate as if it had arrived over
-  /// the real port. Exposed for testing the reporting mechanism without
-  /// spawning a real isolate.
-  @visibleForTesting
-  void handleMonitorMessage(dynamic message) => _handleMonitorMessage(message);
-
-  void _handleMonitorMessage(dynamic message) {
-    if (message is SendPort) {
-      _monitorSendPort = message;
-    } else if (message is int) {
-      _monitorSendPort?.send(message);
-    } else if (message is List) {
-      _recordHang(message[0] as int, message[1] as int);
+  void _handleTick(DateTime now) {
+    final resolved = _tracker?.onTick(now);
+    if (resolved != null) {
+      unawaited(
+        _recordHang(
+          resolved.start.millisecondsSinceEpoch,
+          resolved.end.millisecondsSinceEpoch,
+        ),
+      );
     }
   }
 
@@ -240,32 +157,4 @@ class EmbraceHangDetector with WidgetsBindingObserver {
       attributes: {'duration_ms': (endTimeMs - startTimeMs).toString()},
     );
   }
-}
-
-void _monitorEntryPoint(List<dynamic> args) {
-  final mainSendPort = args[0] as SendPort;
-  final pingInterval = Duration(milliseconds: args[1] as int);
-  final hangThreshold = Duration(milliseconds: args[2] as int);
-
-  final monitorReceivePort = ReceivePort();
-  mainSendPort.send(monitorReceivePort.sendPort);
-
-  final tracker = EmbraceHangTracker(hangThreshold);
-
-  monitorReceivePort.listen((dynamic message) {
-    if (message is! int) return;
-    final resolved = tracker.onEcho(DateTime.now());
-    if (resolved != null) {
-      mainSendPort.send([
-        resolved.start.millisecondsSinceEpoch,
-        resolved.end.millisecondsSinceEpoch,
-      ]);
-    }
-  });
-
-  Timer.periodic(pingInterval, (_) {
-    final now = DateTime.now();
-    tracker.onTick(now);
-    mainSendPort.send(now.millisecondsSinceEpoch);
-  });
 }

--- a/embrace/lib/src/embrace_hang_detector.dart
+++ b/embrace/lib/src/embrace_hang_detector.dart
@@ -3,6 +3,15 @@ import 'dart:isolate';
 
 import 'package:embrace_platform_interface/embrace_platform_interface.dart';
 import 'package:flutter/widgets.dart';
+import 'package:meta/meta.dart';
+
+EmbraceHangDetector? _activeDetector;
+
+@internal
+// Called by Embrace.disable() to tear down hang detection.
+void stopActiveHangDetector() {
+  _activeDetector?.stop();
+}
 
 /// Configuration for the Dart UI isolate hang detector's ping interval and
 /// hang threshold.
@@ -99,6 +108,7 @@ class EmbraceHangDetector with WidgetsBindingObserver {
   /// observing app lifecycle changes so monitoring can pause while
   /// backgrounded.
   Future<void> start() async {
+    _activeDetector = this;
     WidgetsBinding.instance.addObserver(this);
     await _startMonitoring();
   }
@@ -106,6 +116,7 @@ class EmbraceHangDetector with WidgetsBindingObserver {
   /// Kills the monitor isolate, stops listening for its messages, and stops
   /// observing app lifecycle changes.
   void stop() {
+    if (_activeDetector == this) _activeDetector = null;
     WidgetsBinding.instance.removeObserver(this);
     _stopMonitoring();
   }

--- a/embrace/lib/src/embrace_hang_detector.dart
+++ b/embrace/lib/src/embrace_hang_detector.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'dart:isolate';
 
 import 'package:embrace_platform_interface/embrace_platform_interface.dart';
+import 'package:meta/meta.dart';
 
 /// Configuration for the Dart UI isolate hang detector's ping interval and
 /// hang threshold.
@@ -77,6 +78,8 @@ class EmbraceHangDetector {
   final EmbraceHangDetectionConfig _config;
 
   ReceivePort? _mainReceivePort;
+  ReceivePort? _errorPort;
+  ReceivePort? _exitPort;
   Isolate? _monitorIsolate;
   SendPort? _monitorSendPort;
 
@@ -86,6 +89,14 @@ class EmbraceHangDetector {
     _mainReceivePort = mainReceivePort;
     mainReceivePort.listen(_handleMonitorMessage);
 
+    final errorPort = ReceivePort();
+    _errorPort = errorPort;
+    errorPort.listen(_handleMonitorError);
+
+    final exitPort = ReceivePort();
+    _exitPort = exitPort;
+    exitPort.listen((_) => _closeErrorAndExitPorts());
+
     _monitorIsolate = await Isolate.spawn(
       _monitorEntryPoint,
       [
@@ -93,6 +104,8 @@ class EmbraceHangDetector {
         _config.pingInterval.inMilliseconds,
         _config.hangThreshold.inMilliseconds,
       ],
+      onError: errorPort.sendPort,
+      onExit: exitPort.sendPort,
     );
   }
 
@@ -103,7 +116,43 @@ class EmbraceHangDetector {
     _mainReceivePort?.close();
     _mainReceivePort = null;
     _monitorSendPort = null;
+    _closeErrorAndExitPorts();
   }
+
+  void _closeErrorAndExitPorts() {
+    _errorPort?.close();
+    _errorPort = null;
+    _exitPort?.close();
+    _exitPort = null;
+  }
+
+  /// Handles an uncaught error from the monitor isolate as if it had
+  /// arrived over the real error port. Exposed for testing error forwarding
+  /// without spawning a real isolate.
+  @visibleForTesting
+  void handleMonitorError(dynamic message) => _handleMonitorError(message);
+
+  void _handleMonitorError(dynamic message) {
+    _closeErrorAndExitPorts();
+
+    final params = message as List<dynamic>;
+    final error = params[0] as String;
+    final stackTrace = params[1] as String;
+    EmbracePlatform.instance.logDartError(
+      stackTrace,
+      error,
+      "Uncaught error in the Dart UI isolate hang detector's monitor "
+      'isolate',
+      null,
+      errorType: 'IsolateUncaughtError',
+    );
+  }
+
+  /// Handles a message from the monitor isolate as if it had arrived over
+  /// the real port. Exposed for testing the reporting mechanism without
+  /// spawning a real isolate.
+  @visibleForTesting
+  void handleMonitorMessage(dynamic message) => _handleMonitorMessage(message);
 
   void _handleMonitorMessage(dynamic message) {
     if (message is SendPort) {

--- a/embrace/lib/src/embrace_hang_detector.dart
+++ b/embrace/lib/src/embrace_hang_detector.dart
@@ -1,0 +1,16 @@
+/// Configuration for the Dart UI isolate hang detector's ping interval and
+/// hang threshold.
+class EmbraceHangDetectionConfig {
+  /// Creates a hang-detection configuration.
+  const EmbraceHangDetectionConfig({
+    this.pingInterval = const Duration(milliseconds: 1000),
+    this.hangThreshold = const Duration(milliseconds: 700),
+  });
+
+  /// How often the monitor isolate pings the main isolate.
+  final Duration pingInterval;
+
+  /// How long the main isolate can go without echoing a ping before it's
+  /// considered hung.
+  final Duration hangThreshold;
+}

--- a/embrace/test/src/embrace_hang_detector_test.dart
+++ b/embrace/test/src/embrace_hang_detector_test.dart
@@ -1,11 +1,14 @@
 import 'package:embrace/src/embrace_hang_detector.dart';
 import 'package:embrace_platform_interface/embrace_platform_interface.dart';
+import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 
 import 'observer_test_helpers.dart';
 
 void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
   group('EmbraceHangDetectionConfig', () {
     test('has expected defaults', () {
       const config = EmbraceHangDetectionConfig();
@@ -132,6 +135,66 @@ void main() {
           errorType: 'IsolateUncaughtError',
         ),
       ).called(1);
+    });
+
+    test('stops monitoring when the app is backgrounded', () async {
+      final detector = EmbraceHangDetector();
+      await detector.start();
+      expect(detector.isMonitoring, isTrue);
+
+      detector.didChangeAppLifecycleState(AppLifecycleState.paused);
+
+      expect(detector.isMonitoring, isFalse);
+      detector.stop();
+    });
+
+    test('restarts monitoring when the app returns to the foreground',
+        () async {
+      final detector = EmbraceHangDetector();
+      await detector.start();
+      detector
+        ..didChangeAppLifecycleState(AppLifecycleState.paused)
+        ..didChangeAppLifecycleState(AppLifecycleState.resumed);
+      while (!detector.isMonitoring) {
+        await Future<void>.delayed(const Duration(milliseconds: 10));
+      }
+
+      expect(detector.isMonitoring, isTrue);
+      detector.stop();
+    });
+
+    test(
+        'discards a monitor isolate whose spawn resolves after a later '
+        'pause', () async {
+      final detector = EmbraceHangDetector();
+      await detector.start();
+      detector.didChangeAppLifecycleState(AppLifecycleState.paused);
+      expect(detector.isMonitoring, isFalse);
+
+      // Resume kicks off an unawaited isolate spawn; pausing again right
+      // after races a stop against that still in-flight start.
+      detector
+        ..didChangeAppLifecycleState(AppLifecycleState.resumed)
+        ..didChangeAppLifecycleState(AppLifecycleState.paused);
+
+      // Give the in-flight spawn from the resume above time to resolve.
+      await Future<void>.delayed(const Duration(milliseconds: 200));
+
+      expect(detector.isMonitoring, isFalse);
+      detector.stop();
+    });
+
+    test('ignores transient lifecycle states', () async {
+      final detector = EmbraceHangDetector();
+      await detector.start();
+
+      detector
+        ..didChangeAppLifecycleState(AppLifecycleState.inactive)
+        ..didChangeAppLifecycleState(AppLifecycleState.hidden)
+        ..didChangeAppLifecycleState(AppLifecycleState.detached);
+
+      expect(detector.isMonitoring, isTrue);
+      detector.stop();
     });
   });
 }

--- a/embrace/test/src/embrace_hang_detector_test.dart
+++ b/embrace/test/src/embrace_hang_detector_test.dart
@@ -196,5 +196,21 @@ void main() {
       expect(detector.isMonitoring, isTrue);
       detector.stop();
     });
+
+    group('stopActiveHangDetector', () {
+      test('does nothing when no detector is active', () {
+        expect(stopActiveHangDetector, returnsNormally);
+      });
+
+      test('stops the active detector', () async {
+        final detector = EmbraceHangDetector();
+        await detector.start();
+        expect(detector.isMonitoring, isTrue);
+
+        stopActiveHangDetector();
+
+        expect(detector.isMonitoring, isFalse);
+      });
+    });
   });
 }

--- a/embrace/test/src/embrace_hang_detector_test.dart
+++ b/embrace/test/src/embrace_hang_detector_test.dart
@@ -13,32 +13,31 @@ void main() {
     test('has expected defaults', () {
       const config = EmbraceHangDetectionConfig();
 
-      expect(config.pingInterval, const Duration(milliseconds: 200));
+      expect(config.tickInterval, const Duration(milliseconds: 200));
       expect(config.hangThreshold, const Duration(milliseconds: 700));
     });
 
     test('accepts custom values', () {
       const config = EmbraceHangDetectionConfig(
-        pingInterval: Duration(milliseconds: 500),
+        tickInterval: Duration(milliseconds: 500),
         hangThreshold: Duration(milliseconds: 300),
       );
 
-      expect(config.pingInterval, const Duration(milliseconds: 500));
+      expect(config.tickInterval, const Duration(milliseconds: 500));
       expect(config.hangThreshold, const Duration(milliseconds: 300));
     });
   });
 
   group('EmbraceHangTracker', () {
-    test('onEcho returns null when the gap is below the hang threshold', () {
+    test('onTick returns null when the gap is below the hang threshold', () {
       final start = DateTime(2026);
       final tracker = EmbraceHangTracker(
         const Duration(milliseconds: 700),
         initialGoodTime: start,
       );
 
-      final resolved = (tracker
-            ..onTick(start.add(const Duration(milliseconds: 200))))
-          .onEcho(start.add(const Duration(milliseconds: 200)));
+      final resolved =
+          tracker.onTick(start.add(const Duration(milliseconds: 200)));
 
       expect(resolved, isNull);
     });
@@ -50,15 +49,14 @@ void main() {
         initialGoodTime: start,
       )
         ..onTick(start.add(const Duration(milliseconds: 200)))
-        ..onTick(start.add(const Duration(milliseconds: 400)))
-        ..onTick(start.add(const Duration(milliseconds: 800)));
+        ..onTick(start.add(const Duration(milliseconds: 400)));
 
-      final echoTime = start.add(const Duration(milliseconds: 900));
-      final resolved = tracker.onEcho(echoTime);
+      final tickTime = start.add(const Duration(milliseconds: 1200));
+      final resolved = tracker.onTick(tickTime);
 
       expect(resolved, isNotNull);
-      expect(resolved!.start, start);
-      expect(resolved.end, echoTime);
+      expect(resolved!.start, start.add(const Duration(milliseconds: 400)));
+      expect(resolved.end, tickTime);
     });
 
     test('does not re-report once a hang has been resolved', () {
@@ -68,13 +66,12 @@ void main() {
         initialGoodTime: start,
       );
 
-      final firstEcho = start.add(const Duration(milliseconds: 900));
-      (tracker..onTick(start.add(const Duration(milliseconds: 800))))
-          .onEcho(firstEcho);
+      final firstHangTick = start.add(const Duration(milliseconds: 900));
+      tracker.onTick(firstHangTick);
 
-      final secondEchoTime = firstEcho.add(const Duration(milliseconds: 200));
-      tracker.onTick(secondEchoTime);
-      final resolved = tracker.onEcho(secondEchoTime);
+      final secondTickTime =
+          firstHangTick.add(const Duration(milliseconds: 200));
+      final resolved = tracker.onTick(secondTickTime);
 
       expect(resolved, isNull);
     });
@@ -103,38 +100,32 @@ void main() {
       expect(detector.stop, returnsNormally);
     });
 
-    test('records a completed span when a hang is reported', () {
-      EmbraceHangDetector().handleMonitorMessage([1000, 1700]);
+    test('records a completed span when a hang is reported', () async {
+      final start = DateTime(2026);
+      final detector = EmbraceHangDetector();
+      await detector.start();
+      detector
+        ..handleTick(start)
+        ..handleTick(start.add(const Duration(milliseconds: 200)))
+        ..handleTick(start.add(const Duration(milliseconds: 900)))
+        ..stop();
+      await Future<void>.delayed(Duration.zero);
 
       verify(
         () => platform.recordCompletedSpan(
           'emb-dart-isolate-hang',
-          1000,
-          1700,
+          start.add(const Duration(milliseconds: 200)).millisecondsSinceEpoch,
+          start.add(const Duration(milliseconds: 900)).millisecondsSinceEpoch,
           attributes: {'duration_ms': '700'},
         ),
       ).called(1);
     });
 
-    test('ignores ping tokens and handshake messages', () {
+    test('ignores ticks with no active tracker', () {
       final detector = EmbraceHangDetector();
 
-      expect(() => detector.handleMonitorMessage(1234), returnsNormally);
+      expect(() => detector.handleTick(DateTime.now()), returnsNormally);
       verifyNever(() => platform.recordCompletedSpan(any(), any(), any()));
-    });
-
-    test('forwards uncaught errors from the monitor isolate', () {
-      EmbraceHangDetector().handleMonitorError(['Exception: boom', '#0 main']);
-
-      verify(
-        () => platform.logDartError(
-          '#0 main',
-          'Exception: boom',
-          any(),
-          null,
-          errorType: 'IsolateUncaughtError',
-        ),
-      ).called(1);
     });
 
     test('stops monitoring when the app is backgrounded', () async {
@@ -155,32 +146,8 @@ void main() {
       detector
         ..didChangeAppLifecycleState(AppLifecycleState.paused)
         ..didChangeAppLifecycleState(AppLifecycleState.resumed);
-      while (!detector.isMonitoring) {
-        await Future<void>.delayed(const Duration(milliseconds: 10));
-      }
 
       expect(detector.isMonitoring, isTrue);
-      detector.stop();
-    });
-
-    test(
-        'discards a monitor isolate whose spawn resolves after a later '
-        'pause', () async {
-      final detector = EmbraceHangDetector();
-      await detector.start();
-      detector.didChangeAppLifecycleState(AppLifecycleState.paused);
-      expect(detector.isMonitoring, isFalse);
-
-      // Resume kicks off an unawaited isolate spawn; pausing again right
-      // after races a stop against that still in-flight start.
-      detector
-        ..didChangeAppLifecycleState(AppLifecycleState.resumed)
-        ..didChangeAppLifecycleState(AppLifecycleState.paused);
-
-      // Give the in-flight spawn from the resume above time to resolve.
-      await Future<void>.delayed(const Duration(milliseconds: 200));
-
-      expect(detector.isMonitoring, isFalse);
       detector.stop();
     });
 

--- a/embrace/test/src/embrace_hang_detector_test.dart
+++ b/embrace/test/src/embrace_hang_detector_test.dart
@@ -1,0 +1,23 @@
+import 'package:embrace/src/embrace_hang_detector.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('EmbraceHangDetectionConfig', () {
+    test('has expected defaults', () {
+      const config = EmbraceHangDetectionConfig();
+
+      expect(config.pingInterval, const Duration(milliseconds: 1000));
+      expect(config.hangThreshold, const Duration(milliseconds: 700));
+    });
+
+    test('accepts custom values', () {
+      const config = EmbraceHangDetectionConfig(
+        pingInterval: Duration(milliseconds: 500),
+        hangThreshold: Duration(milliseconds: 300),
+      );
+
+      expect(config.pingInterval, const Duration(milliseconds: 500));
+      expect(config.hangThreshold, const Duration(milliseconds: 300));
+    });
+  });
+}

--- a/embrace/test/src/embrace_hang_detector_test.dart
+++ b/embrace/test/src/embrace_hang_detector_test.dart
@@ -13,7 +13,7 @@ void main() {
     test('has expected defaults', () {
       const config = EmbraceHangDetectionConfig();
 
-      expect(config.tickInterval, const Duration(milliseconds: 200));
+      expect(config.tickInterval, const Duration(milliseconds: 100));
       expect(config.hangThreshold, const Duration(milliseconds: 700));
     });
 

--- a/embrace/test/src/embrace_hang_detector_test.dart
+++ b/embrace/test/src/embrace_hang_detector_test.dart
@@ -6,7 +6,7 @@ void main() {
     test('has expected defaults', () {
       const config = EmbraceHangDetectionConfig();
 
-      expect(config.pingInterval, const Duration(milliseconds: 1000));
+      expect(config.pingInterval, const Duration(milliseconds: 200));
       expect(config.hangThreshold, const Duration(milliseconds: 700));
     });
 
@@ -18,6 +18,67 @@ void main() {
 
       expect(config.pingInterval, const Duration(milliseconds: 500));
       expect(config.hangThreshold, const Duration(milliseconds: 300));
+    });
+  });
+
+  group('EmbraceHangTracker', () {
+    test('onEcho returns null when the gap is below the hang threshold', () {
+      final start = DateTime(2026);
+      final tracker = EmbraceHangTracker(
+        const Duration(milliseconds: 700),
+        initialGoodTime: start,
+      );
+
+      final resolved = (tracker
+            ..onTick(start.add(const Duration(milliseconds: 200))))
+          .onEcho(start.add(const Duration(milliseconds: 200)));
+
+      expect(resolved, isNull);
+    });
+
+    test('records a hang once the threshold is crossed', () {
+      final start = DateTime(2026);
+      final tracker = EmbraceHangTracker(
+        const Duration(milliseconds: 700),
+        initialGoodTime: start,
+      )
+        ..onTick(start.add(const Duration(milliseconds: 200)))
+        ..onTick(start.add(const Duration(milliseconds: 400)))
+        ..onTick(start.add(const Duration(milliseconds: 800)));
+
+      final echoTime = start.add(const Duration(milliseconds: 900));
+      final resolved = tracker.onEcho(echoTime);
+
+      expect(resolved, isNotNull);
+      expect(resolved!.start, start);
+      expect(resolved.end, echoTime);
+    });
+
+    test('does not re-report once a hang has been resolved', () {
+      final start = DateTime(2026);
+      final tracker = EmbraceHangTracker(
+        const Duration(milliseconds: 700),
+        initialGoodTime: start,
+      );
+
+      final firstEcho = start.add(const Duration(milliseconds: 900));
+      (tracker..onTick(start.add(const Duration(milliseconds: 800))))
+          .onEcho(firstEcho);
+
+      final secondEchoTime = firstEcho.add(const Duration(milliseconds: 200));
+      tracker.onTick(secondEchoTime);
+      final resolved = tracker.onEcho(secondEchoTime);
+
+      expect(resolved, isNull);
+    });
+  });
+
+  group('EmbraceHangDetector', () {
+    test('start and stop do not throw', () async {
+      final detector = EmbraceHangDetector();
+
+      await detector.start();
+      expect(detector.stop, returnsNormally);
     });
   });
 }

--- a/embrace/test/src/embrace_hang_detector_test.dart
+++ b/embrace/test/src/embrace_hang_detector_test.dart
@@ -1,5 +1,9 @@
 import 'package:embrace/src/embrace_hang_detector.dart';
+import 'package:embrace_platform_interface/embrace_platform_interface.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+
+import 'observer_test_helpers.dart';
 
 void main() {
   group('EmbraceHangDetectionConfig', () {
@@ -74,11 +78,60 @@ void main() {
   });
 
   group('EmbraceHangDetector', () {
+    late MockEmbracePlatform platform;
+
+    setUp(() {
+      platform = MockEmbracePlatform();
+      EmbracePlatform.instance = platform;
+      when(
+        () => platform.recordCompletedSpan(
+          any(),
+          any(),
+          any(),
+          attributes: any(named: 'attributes'),
+        ),
+      ).thenAnswer((_) async => true);
+    });
+
     test('start and stop do not throw', () async {
       final detector = EmbraceHangDetector();
 
       await detector.start();
       expect(detector.stop, returnsNormally);
+    });
+
+    test('records a completed span when a hang is reported', () {
+      EmbraceHangDetector().handleMonitorMessage([1000, 1700]);
+
+      verify(
+        () => platform.recordCompletedSpan(
+          'emb-dart-isolate-hang',
+          1000,
+          1700,
+          attributes: {'duration_ms': '700'},
+        ),
+      ).called(1);
+    });
+
+    test('ignores ping tokens and handshake messages', () {
+      final detector = EmbraceHangDetector();
+
+      expect(() => detector.handleMonitorMessage(1234), returnsNormally);
+      verifyNever(() => platform.recordCompletedSpan(any(), any(), any()));
+    });
+
+    test('forwards uncaught errors from the monitor isolate', () {
+      EmbraceHangDetector().handleMonitorError(['Exception: boom', '#0 main']);
+
+      verify(
+        () => platform.logDartError(
+          '#0 main',
+          'Exception: boom',
+          any(),
+          null,
+          errorType: 'IsolateUncaughtError',
+        ),
+      ).called(1);
     });
   });
 }


### PR DESCRIPTION
## Summary
- Adds `EmbraceHangDetector`, which runs a `Timer.periodic` directly on the main (UI) Dart isolate and records a completed span (`emb-dart-isolate-hang`) whenever a tick fires more than `hangThreshold` after the previous one — filling a gap neither iOS watchdog kills nor Android ANR detection can see, since Flutter's UI thread is a Dart isolate rather than the platform's native main thread.
- A tick firing at all proves the event loop just ran, so the gap since the last tick is itself the signal — no separate isolate or ping/echo round trip is needed to detect the stall.
- Wired into `Embrace.start()` alongside the existing frame detector.
- Pauses monitoring on `AppLifecycleState.paused` and restarts fresh (new timer, new tracker) on `.resumed`, since the OS may suspend the whole process while backgrounded — without this, resuming would surface as a bogus hang spanning the entire backgrounded period. This mirrors the pause/resume behavior in `embrace-android`'s ANR detector (`ThreadBlockageServiceImpl.onBackground()`/`onForeground()`).
- Stacked on #353: wires `EmbraceHangDetector.stop()` into `Embrace.disable()` via a `stopActiveHangDetector()` hook, mirroring `stopActiveFrameDetector()`.

## Test plan
- [x] `flutter analyze` clean in `embrace`
- [x] `flutter test` passes in `embrace` (282 tests)