### PR TITLE
feat: add EmbraceLifecycleObserver to track app background spans

### DIFF
--- a/embrace/lib/embrace.dart
+++ b/embrace/lib/embrace.dart
@@ -7,6 +7,7 @@ import 'package:embrace/embrace_api.dart';
 import 'package:embrace/src/embrace_frame_detector.dart';
 import 'package:embrace/src/embrace_hang_detector.dart';
 import 'package:embrace/src/embrace_startup_tracker.dart';
+import 'package:embrace/src/lifecycle_observer.dart';
 import 'package:embrace/src/otel/otel.dart';
 import 'package:embrace/src/pointer_input_tracker.dart';
 import 'package:embrace_platform_interface/embrace_platform_interface.dart';
@@ -15,6 +16,7 @@ import 'package:flutter/widgets.dart';
 
 export 'package:embrace_platform_interface/http_method.dart' show HttpMethod;
 export 'src/http_client.dart';
+export 'src/lifecycle_observer.dart' hide stopActiveLifecycleObserver;
 export 'src/navigation_observer.dart';
 export 'src/otel/propagation/w3c_trace_context.dart';
 
@@ -104,6 +106,7 @@ class Embrace implements EmbraceFlutterApi {
     _runCatching('disable', () {
       stopActiveFrameDetector();
       stopActiveHangDetector();
+      stopActiveLifecycleObserver();
       _platform.disable();
     });
   }
@@ -580,6 +583,7 @@ Future<void> _start(
 
   EmbraceFrameDetector().start();
   await EmbraceHangDetector().start();
+  EmbraceLifecycleObserver().start();
 
   if (action != null) {
     await _installErrorHandlers(action);

--- a/embrace/lib/src/lifecycle_observer.dart
+++ b/embrace/lib/src/lifecycle_observer.dart
@@ -1,0 +1,81 @@
+import 'dart:async';
+
+import 'package:embrace/embrace.dart';
+import 'package:embrace/embrace_api.dart';
+import 'package:flutter/widgets.dart';
+import 'package:meta/meta.dart';
+
+EmbraceLifecycleObserver? _activeObserver;
+
+@internal
+// Called by Embrace.disable() to tear down lifecycle observation.
+void stopActiveLifecycleObserver() {
+  _activeObserver?.stop();
+}
+
+/// A [WidgetsBindingObserver] that tracks app foreground/background lifecycle.
+class EmbraceLifecycleObserver with WidgetsBindingObserver {
+  EmbraceSpan? _backgroundSpan;
+  bool _isBackground = false;
+
+  /// Begins observing app lifecycle changes.
+  void start() {
+    _activeObserver = this;
+    WidgetsBinding.instance.addObserver(this);
+  }
+
+  /// Stops observing app lifecycle changes and closes any open background
+  /// span.
+  void stop() {
+    if (_activeObserver == this) _activeObserver = null;
+    WidgetsBinding.instance.removeObserver(this);
+    _isBackground = false;
+    _stopBackgroundSpan();
+  }
+
+  @override
+  void didChangeAppLifecycleState(AppLifecycleState state) {
+    switch (state) {
+      case AppLifecycleState.paused:
+        _onPaused();
+      case AppLifecycleState.resumed:
+        _onResumed();
+      case AppLifecycleState.detached:
+        _onDetached();
+      case _:
+        break;
+    }
+  }
+
+  void _onPaused() {
+    if (_isBackground) return;
+    _isBackground = true;
+    Embrace.instance.startSpan('emb-app-background').then(
+      (span) {
+        _backgroundSpan = span;
+        if (!_isBackground) {
+          _stopBackgroundSpan();
+        }
+      },
+      onError: (_, __) {},
+    );
+  }
+
+  void _onResumed() {
+    _isBackground = false;
+    _stopBackgroundSpan();
+  }
+
+  void _onDetached() {
+    _isBackground = false;
+    _stopBackgroundSpan();
+  }
+
+  void _stopBackgroundSpan() {
+    final span = _backgroundSpan;
+    _backgroundSpan = null;
+    if (span != null) {
+      unawaited(span.stop());
+    }
+  }
+}

--- a/embrace/test/src/lifecycle_observer_test.dart
+++ b/embrace/test/src/lifecycle_observer_test.dart
@@ -1,0 +1,139 @@
+import 'package:embrace/embrace.dart';
+import 'package:embrace/src/lifecycle_observer.dart'
+    show stopActiveLifecycleObserver;
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+
+import 'observer_test_helpers.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late EmbraceLifecycleObserver observer;
+  late MockEmbrace mockEmbrace;
+  late MockEmbraceSpan mockSpan;
+
+  setUpAll(() {
+    registerFallbackValue('');
+  });
+
+  setUp(() {
+    mockEmbrace = MockEmbrace();
+    mockSpan = MockEmbraceSpan();
+    // ignore: invalid_use_of_visible_for_testing_member
+    debugEmbraceOverride = mockEmbrace;
+    when(() => mockEmbrace.startSpan('emb-app-background'))
+        .thenAnswer((_) => Future.value(mockSpan));
+    when(mockSpan.stop).thenAnswer((_) async => true);
+    observer = EmbraceLifecycleObserver();
+  });
+
+  tearDown(() {
+    // ignore: invalid_use_of_visible_for_testing_member
+    debugEmbraceOverride = null;
+  });
+
+  group('EmbraceLifecycleObserver', () {
+    test('starts background span on paused', () async {
+      observer.didChangeAppLifecycleState(AppLifecycleState.paused);
+      await Future<void>.value();
+
+      verify(() => mockEmbrace.startSpan('emb-app-background')).called(1);
+    });
+
+    test('stops background span on resumed after paused', () async {
+      observer.didChangeAppLifecycleState(AppLifecycleState.paused);
+      await Future<void>.value();
+      observer.didChangeAppLifecycleState(AppLifecycleState.resumed);
+
+      verify(mockSpan.stop).called(1);
+    });
+
+    test('stops background span on detached after paused', () async {
+      observer.didChangeAppLifecycleState(AppLifecycleState.paused);
+      await Future<void>.value();
+      observer.didChangeAppLifecycleState(AppLifecycleState.detached);
+
+      verify(mockSpan.stop).called(1);
+    });
+
+    test('does not stop span when resumed with no prior pause', () {
+      observer.didChangeAppLifecycleState(AppLifecycleState.resumed);
+      verifyNever(mockSpan.stop);
+    });
+
+    test('does not start background span on inactive', () {
+      observer.didChangeAppLifecycleState(AppLifecycleState.inactive);
+      verifyNever(() => mockEmbrace.startSpan(any()));
+    });
+
+    test(
+      'stops span immediately if resumed before startSpan resolves',
+      () async {
+        observer
+          ..didChangeAppLifecycleState(AppLifecycleState.paused)
+          ..didChangeAppLifecycleState(AppLifecycleState.resumed);
+        await Future<void>.value();
+
+        verify(mockSpan.stop).called(1);
+      },
+    );
+
+    test(
+      'does not start duplicate background span on repeated paused',
+      () async {
+        observer.didChangeAppLifecycleState(AppLifecycleState.paused);
+        await Future<void>.value();
+        observer.didChangeAppLifecycleState(AppLifecycleState.paused);
+        await Future<void>.value();
+
+        verify(() => mockEmbrace.startSpan('emb-app-background')).called(1);
+      },
+    );
+
+    test('stops background span when resumed after repeated paused', () async {
+      observer.didChangeAppLifecycleState(AppLifecycleState.paused);
+      await Future<void>.value();
+      observer.didChangeAppLifecycleState(AppLifecycleState.paused);
+      await Future<void>.value();
+      observer.didChangeAppLifecycleState(AppLifecycleState.resumed);
+
+      verify(mockSpan.stop).called(1);
+    });
+
+    test('start and stop do not throw', () {
+      observer.start();
+      expect(observer.stop, returnsNormally);
+    });
+
+    test('stop closes an open background span', () async {
+      observer
+        ..start()
+        ..didChangeAppLifecycleState(AppLifecycleState.paused);
+      await Future<void>.value();
+
+      observer.stop();
+
+      verify(mockSpan.stop).called(1);
+    });
+
+    group('stopActiveLifecycleObserver', () {
+      test('does nothing when no observer is active', () {
+        expect(stopActiveLifecycleObserver, returnsNormally);
+      });
+
+      test('stops the active observer, closing an open background span',
+          () async {
+        observer
+          ..start()
+          ..didChangeAppLifecycleState(AppLifecycleState.paused);
+        await Future<void>.value();
+
+        stopActiveLifecycleObserver();
+
+        verify(mockSpan.stop).called(1);
+      });
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- Registers a `WidgetsBindingObserver` on `Embrace.start()` that opens an `emb-app-background` span when the app is paused, and closes it on resume or detach.
- Guards against duplicate spans on repeated pause events; uses `unawaited()` for fire-and-forget span stops.
- Wires teardown into `Embrace.disable()` via `stopActiveLifecycleObserver()`, following the same active-instance pattern as `EmbraceFrameDetector`/`EmbraceHangDetector`.

Reopens #257, which went stale and was auto-closed without merging. Rebased onto current `main` (134 commits since the original branch point) and updated to match the `start()`/`stop()` + `Embrace.disable()` integration pattern introduced since then.

## Test plan
- [x] `flutter analyze` clean
- [x] `flutter test` — all tests pass, including new coverage for `start()`/`stop()` and `stopActiveLifecycleObserver()`